### PR TITLE
🩹 Update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
   "solidity.formatter": "forge",
-  "solidity.defaultCompiler": "localFile"
+  "solidity.defaultCompiler": "localFile",
+  "solidity.packageDefaultDependenciesDirectory": "lib",
+  "solidity.packageDefaultDependenciesContractsDirectory": "src"
 }


### PR DESCRIPTION
## Description

added default dependency and contract directory to `.vscode/settings.json` to prevent occasional linter errors in vscode

## Changes

- [x] deps: lib, contracts: src

## Checklist

- [x] `forge fmt`
- [x] `forge test`
