### PR TITLE
✨ add CREATE3Factory and test utils

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "solidity.formatter": "forge",
   "solidity.defaultCompiler": "localFile",
+  "solidity.monoRepoSupport": true,
   "solidity.packageDefaultDependenciesDirectory": "lib",
   "solidity.packageDefaultDependenciesContractsDirectory": "src"
 }

--- a/script/DeployCREATE3Factory.s.sol
+++ b/script/DeployCREATE3Factory.s.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {CREATE3Factory} from "../src/CREATE3Factory.sol";
+
+import {Utils} from "../script/utils/Utils.sol";
+
+contract DeployCREATE3Factory is Utils {
+    CREATE3Factory factory;
+
+    address deployer;
+
+    function run() public {
+        uint256 privateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        require(privateKey != 0, "DEPLOYER_PRIVATE_KEY not set");
+
+        deployer = vm.addr(privateKey);
+        vm.startBroadcast(privateKey);
+
+        factory = new CREATE3Factory();
+        require(address(factory) != address(0), "CREATE3Factory deployment failed");
+
+        vm.stopBroadcast();
+
+        _serializeDeploymentData();
+    }
+
+    function _serializeDeploymentData() internal {
+        string memory parent_object = "parent object";
+        string memory addresses = "addresses";
+        string memory constructorArgs = "constructorArgs";
+
+        string memory addressesOutput;
+        addressesOutput = vm.serializeAddress(addresses, "deployer", deployer);
+        addressesOutput = vm.serializeAddress(addresses, "implementation", address(factory));
+
+        string memory constructorArgsOutput;
+
+        string memory finalJson;
+        finalJson = vm.serializeString(parent_object, addresses, addressesOutput);
+        finalJson = vm.serializeString(parent_object, constructorArgs, constructorArgsOutput);
+        finalJson = vm.serializeUint(parent_object, "deploymentBlock", block.number);
+
+        writeOutput(finalJson, "CREATE3Factory");
+    }
+}

--- a/script/utils/Utils.sol
+++ b/script/utils/Utils.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+
+contract Utils is Script {
+    uint256 constant CHAIN_ID_ANVIL_LOCALNET = 31_337;
+
+    string constant OUTPUT_ANVIL_LOCALNET = "anvil_localnet";
+    string constant OUTPUT_UNKNOWN = "unknown";
+
+    function readInput(string memory inputFileName) internal view returns (string memory) {
+        string memory file = getInputPath(inputFileName);
+        return vm.readFile(file);
+    }
+
+    function getInputPath(string memory inputFileName) internal view returns (string memory) {
+        string memory inputDir = string.concat(vm.projectRoot(), "/deployments/");
+        string memory file = string.concat(inputFileName, ".json");
+        return string.concat(inputDir, file);
+    }
+
+    function readOutput(string memory outputFileName) internal view returns (string memory) {
+        string memory file = getOutputPath(outputFileName);
+        return vm.readFile(file);
+    }
+
+    function writeOutput(string memory outputJson, string memory outputFileName) internal {
+        string memory outputFilePath = getOutputPath(outputFileName);
+        vm.writeJson(outputJson, outputFilePath);
+    }
+
+    function getOutputPath(string memory outputFileName) internal view returns (string memory) {
+        string memory outputDir = string.concat(vm.projectRoot(), "/deployments/");
+        string memory outputFilePath = string.concat(outputDir, outputFileName, ".json");
+        return outputFilePath;
+    }
+}

--- a/src/CREATE3Factory.sol
+++ b/src/CREATE3Factory.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.20;
+
+import {CREATE3} from "./utils/CREATE3.sol";
+
+import {ICREATE3Factory} from "./interfaces/ICREATE3Factory.sol";
+
+/**
+ * @title Factory for deploying contracts to deterministic addresses via CREATE3
+ * @notice Enables deploying contracts using CREATE3. Each deployer (msg.sender) has
+ * its own namespace for deployed addresses.
+ */
+contract CREATE3Factory is ICREATE3Factory {
+    /// @inheritdoc	ICREATE3Factory
+    function deploy(bytes32 salt, bytes memory initCode) external payable returns (address deployed) {
+        return CREATE3.deployDeterministic(msg.value, initCode, keccak256(abi.encodePacked(msg.sender, salt)));
+    }
+
+    /// @inheritdoc	ICREATE3Factory
+    function predictDeterministicAddress(bytes32 salt, address deployer) external view returns (address predicted) {
+        return CREATE3.predictDeterministicAddress(keccak256(abi.encodePacked(deployer, salt)));
+    }
+}

--- a/src/interfaces/ICREATE3Factory.sol
+++ b/src/interfaces/ICREATE3Factory.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title  ICREATE3Factory
+ * @notice This interface defines a CREATE3Factory that can be used to deploy contracts to deterministic addresses.
+ */
+interface ICREATE3Factory {
+    /**
+     * @notice Deploys a contract using CREATE3.
+     * @dev The provided salt is hashed with the deployer's address (msg.sender) to generate the final salt.
+     *      The deployed contract can be funded, msg.value is forwarded to the deployed contract.
+     * @param salt The salt for determining the deployed contract's address.
+     * @param initCode The creation code of the contract to deploy.
+     * @return deployed The address of the deployed contract.
+     */
+    function deploy(bytes32 salt, bytes memory initCode) external payable returns (address deployed);
+
+    /**
+     * @notice Predicts the address of a deployed contract.
+     * @param salt The salt for determining the deployed contract's address.
+     * @param deployer The address of the deployer.
+     * @return predicted The address of the contract that will be deployed.
+     */
+    function predictDeterministicAddress(bytes32 salt, address deployer) external view returns (address predicted);
+}

--- a/src/utils/CREATE3.sol
+++ b/src/utils/CREATE3.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @notice Deterministic deployments agnostic to the initialization code.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/CREATE3.sol)
+/// @author Modified from Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/CREATE3.sol)
+/// @author Modified from 0xSequence (https://github.com/0xSequence/create3/blob/master/contracts/Create3.sol)
+library CREATE3 {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        CUSTOM ERRORS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Unable to deploy the contract.
+    error DeploymentFailed();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      BYTECODE CONSTANTS                    */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /**
+     * -------------------------------------------------------------------+
+     * Opcode      | Mnemonic         | Stack        | Memory             |
+     * -------------------------------------------------------------------|
+     * 36          | CALLDATASIZE     | cds          |                    |
+     * 3d          | RETURNDATASIZE   | 0 cds        |                    |
+     * 3d          | RETURNDATASIZE   | 0 0 cds      |                    |
+     * 37          | CALLDATACOPY     |              | [0..cds): calldata |
+     * 36          | CALLDATASIZE     | cds          | [0..cds): calldata |
+     * 3d          | RETURNDATASIZE   | 0 cds        | [0..cds): calldata |
+     * 34          | CALLVALUE        | value 0 cds  | [0..cds): calldata |
+     * f0          | CREATE           | newContract  | [0..cds): calldata |
+     * -------------------------------------------------------------------|
+     * Opcode      | Mnemonic         | Stack        | Memory             |
+     * -------------------------------------------------------------------|
+     * 67 bytecode | PUSH8 bytecode   | bytecode     |                    |
+     * 3d          | RETURNDATASIZE   | 0 bytecode   |                    |
+     * 52          | MSTORE           |              | [0..8): bytecode   |
+     * 60 0x08     | PUSH1 0x08       | 0x08         | [0..8): bytecode   |
+     * 60 0x18     | PUSH1 0x18       | 0x18 0x08    | [0..8): bytecode   |
+     * f3          | RETURN           |              | [0..8): bytecode   |
+     * -------------------------------------------------------------------+
+     */
+
+    /// @dev The proxy initialization code.
+    uint256 private constant _PROXY_INITCODE = 0x67363d3d37363d34f03d5260086018f3;
+
+    /// @dev Hash of the `_PROXY_INITCODE`.
+    /// Equivalent to `keccak256(abi.encodePacked(hex"67363d3d37363d34f03d5260086018f3"))`.
+    bytes32 internal constant PROXY_INITCODE_HASH = 0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      CREATE3 OPERATIONS                    */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Deploys `initCode` deterministically with a `salt`.
+    /// Returns the deterministic address of the deployed contract,
+    /// which solely depends on `salt`.
+    function deployDeterministic(bytes memory initCode, bytes32 salt) internal returns (address deployed) {
+        deployed = deployDeterministic(0, initCode, salt);
+    }
+
+    /// @dev Deploys `initCode` deterministically with a `salt`.
+    /// The deployed contract is funded with `value` (in wei) ETH.
+    /// Returns the deterministic address of the deployed contract,
+    /// which solely depends on `salt`.
+    function deployDeterministic(uint256 value, bytes memory initCode, bytes32 salt)
+        internal
+        returns (address deployed)
+    {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, _PROXY_INITCODE) // Store the `_PROXY_INITCODE`.
+            let proxy := create2(0, 0x10, 0x10, salt)
+            if iszero(proxy) {
+                mstore(0x00, 0x30116425) // `DeploymentFailed()`.
+                revert(0x1c, 0x04)
+            }
+            mstore(0x14, proxy) // Store the proxy's address.
+            // 0xd6 = 0xc0 (short RLP prefix) + 0x16 (length of: 0x94 ++ proxy ++ 0x01).
+            // 0x94 = 0x80 + 0x14 (0x14 = the length of an address, 20 bytes, in hex).
+            mstore(0x00, 0xd694)
+            mstore8(0x34, 0x01) // Nonce of the proxy contract (1).
+            deployed := keccak256(0x1e, 0x17)
+            if iszero(
+                mul( // The arguments of `mul` are evaluated last to first.
+                extcodesize(deployed), call(gas(), proxy, value, add(initCode, 0x20), mload(initCode), 0x00, 0x00))
+            ) {
+                mstore(0x00, 0x30116425) // `DeploymentFailed()`.
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+
+    /// @dev Returns the deterministic address for `salt`.
+    function predictDeterministicAddress(bytes32 salt) internal view returns (address deployed) {
+        deployed = predictDeterministicAddress(salt, address(this));
+    }
+
+    /// @dev Returns the deterministic address for `salt` with `deployer`.
+    function predictDeterministicAddress(bytes32 salt, address deployer) internal pure returns (address deployed) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let m := mload(0x40) // Cache the free memory pointer.
+            mstore(0x00, deployer) // Store `deployer`.
+            mstore8(0x0b, 0xff) // Store the prefix.
+            mstore(0x20, salt) // Store the salt.
+            mstore(0x40, PROXY_INITCODE_HASH) // Store the bytecode hash.
+
+            mstore(0x14, keccak256(0x0b, 0x55)) // Store the proxy's address.
+            mstore(0x40, m) // Restore the free memory pointer.
+            // 0xd6 = 0xc0 (short RLP prefix) + 0x16 (length of: 0x94 ++ proxy ++ 0x01).
+            // 0x94 = 0x80 + 0x14 (0x14 = the length of an address, 20 bytes, in hex).
+            mstore(0x00, 0xd694)
+            mstore8(0x34, 0x01) // Nonce of the proxy contract (1).
+            deployed := keccak256(0x1e, 0x17)
+        }
+    }
+}

--- a/test/utils/Mocks.sol
+++ b/test/utils/Mocks.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockErc20 {
+    function transfer(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+}

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract Utils {
+    function _generatePayload(uint256 length) public pure returns (bytes memory payload) {
+        payload = new bytes(length);
+
+        for (uint256 i; i < payload.length; ++i) {
+            payload[i] = bytes1(uint8(i % 256));
+        }
+    }
+
+    /// @dev This is NOT cryptographically secure. Just good enough for testing.
+    function _genRandomInt(uint256 min, uint256 max) internal view returns (uint256) {
+        return min
+            + (
+                uint256(keccak256(abi.encodePacked(block.timestamp, block.prevrandao, block.number, msg.sender)))
+                    % (max - min + 1)
+            );
+    }
+
+    function _genBytes(uint32 length) internal pure returns (bytes memory message) {
+        message = new bytes(length);
+
+        for (uint256 i; i < length; ++i) {
+            message[i] = bytes1(uint8(i % 256));
+        }
+    }
+
+    function _genString(uint32 length) internal pure returns (string memory) {
+        return string(_genBytes(length));
+    }
+}


### PR DESCRIPTION
add CREATE3Factory contract and deployment script for more robust deterministic contract deployments, as well as utility and mocks for testing and scripts

## Changes

- [x] add ERC20 mocks and utility contracts to `/test`
- [x] add CREATE3Factory contract, interface, and script

## Checklist

- [x] `forge fmt`
- [x] `forge test`
