### PR TITLE
🐛 fix broken foundry profiles, CI workflows, and documented commands

### DIFF
--- a/.github/workflows/branch-consistency.yml
+++ b/.github/workflows/branch-consistency.yml
@@ -6,51 +6,64 @@ on:
       - main
       - minimal
 
+permissions:
+  contents: read
+
 jobs:
   consistency-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all branches and history
+          fetch-depth: 0 # need full history to read both branches
 
-      # Check consistency of critical files
-      - name: Compare Critical Files
+      # `actions/checkout` only creates a local branch for the ref it checked out.
+      # `main` and `minimal` are reachable as remote-tracking refs, so they have to
+      # be referenced as `origin/<branch>` - `git show main:<file>` fails here.
+      - name: Fetch branches
+        run: git fetch --no-tags origin main minimal
+
+      - name: Report drift in shared files
+        env:
+          # Files that exist on both branches and are expected to stay aligned.
+          # `foundry.toml` is intentionally excluded from the shared set: `minimal`
+          # deliberately omits the Uniswap remappings, so it can never match byte
+          # for byte. It is diffed below for visibility only.
+          SHARED_FILES: .gitignore LICENSE sample.env
         run: |
-          # Ensure both branches exist
-          git branch -r
+          set -euo pipefail
 
-          # List of files to compare
-          critical_files=(
-            "foundry.toml"
-            ".gitignore"
-            "LICENSE"
-            "sample.env"
-          )
+          drift=0
+          {
+            echo "## Branch drift: \`main\` vs \`minimal\`"
+            echo
 
-          # Function to compare files
-          compare_files() {
-            local file="$1"
-            echo "Comparing $file"
-            
-            # Get file contents from both branches
-            main_content=$(git show main:"$file" 2>/dev/null || echo "")
-            minimal_content=$(git show minimal:"$file" 2>/dev/null || echo "")
+            for file in $SHARED_FILES; do
+              if diff_out=$(git diff --no-color "origin/main:$file" "origin/minimal:$file" 2>&1); then
+                echo "- ✅ \`$file\` is identical"
+              else
+                drift=1
+                echo "- ⚠️ \`$file\` differs"
+                echo
+                echo '```diff'
+                echo "$diff_out"
+                echo '```'
+              fi
+            done
 
-            # Compare contents
-            if [ "$main_content" != "$minimal_content" ]; then
-              echo "Inconsistency detected in $file"
-              echo "Main branch content:"
-              echo "$main_content"
-              echo "Minimal branch content:"
-              echo "$minimal_content"
-              exit 1
+            echo
+            echo "<details><summary>foundry.toml diff (informational)</summary>"
+            echo
+            echo '```diff'
+            git diff --no-color origin/main:foundry.toml origin/minimal:foundry.toml || true
+            echo '```'
+            echo
+            echo "</details>"
+
+            if [ "$drift" -eq 1 ]; then
+              echo
+              echo "Drift is expected between merging to \`main\` and running the sync"
+              echo "script, so this check reports rather than blocks. See issue #26 for"
+              echo "the plan to generate \`minimal\` from \`main\` and remove this check."
             fi
-          }
-
-          # Compare each critical file
-          for file in "${critical_files[@]}"; do
-            compare_files "$file"
-          done
-
-          echo "All critical files are consistent between branches."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -6,50 +6,74 @@ on:
 
 # Down scope as necessary via https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
 permissions:
-  checks: write
   contents: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   run-linters:
     name: Run linters
-    if: github.event.issue.pull_request && ${{ github.event.comment.body == '!fix' }}
+    # Only run on PR comments that are exactly `!fix`, and only when the commenter
+    # can already write to the repo. Without the association check, any user could
+    # trigger a job that holds a `contents: write` token.
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '!fix' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
 
     steps:
-      - name: GetBranch
-        id: 'get-branch'
-        run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+      - name: Get PR branch
+        id: get-branch
+        run: |
+          gh pr view "$PR_NO" --repo "$REPO" \
+            --json headRefName,isCrossRepository \
+            --jq '"branch=\(.headRefName)\nis_fork=\(.isCrossRepository)"' >> "$GITHUB_OUTPUT"
         env:
           REPO: ${{ github.repository }}
           PR_NO: ${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # GITHUB_TOKEN cannot push to a fork, so say so instead of failing at `git push`
+      - name: Skip forks
+        if: steps.get-branch.outputs.is_fork == 'true'
+        run: echo "::notice::This PR is from a fork; run 'forge fmt' locally and push instead."
+
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        if: steps.get-branch.outputs.is_fork != 'true'
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.get-branch.outputs.branch }}
 
-
       - name: Install Foundry
+        if: steps.get-branch.outputs.is_fork != 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
-      
+          version: v1.7.1
+
       - name: Lint
-        run: |
-          forge fmt
-          pwd
-          if [[ `git diff --exit-code` ]]; then        
-            git config --local user.name 'GitHub Actions Bot'
-            git config --local user.email '<>'
-            git add .
-            git commit -m "Github Actions automatically updated formatting with forge fmt"
-            COMMIT_HASH=$(git rev-parse HEAD)
-            echo "# Github Actions automatically updated formatting with forge fmt\n$COMMIT_HASH" >> .git-blame-ignore-revs
-            git add .git-blame-ignore-revs
-            git commit -m "Updated .git-blame-ignore-revs with commit $COMMIT_HASH"
-            BRANCH_NAME=$(git symbolic-ref --short HEAD)
-            git push origin $BRANCH_NAME
-          fi
         id: update
+        if: steps.get-branch.outputs.is_fork != 'true'
+        run: |
+          set -euo pipefail
+
+          forge fmt
+
+          if git diff --quiet; then
+            echo "::notice::Formatting is already correct, nothing to fix."
+            exit 0
+          fi
+
+          git config --local user.name 'github-actions[bot]'
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git commit -am "Github Actions automatically updated formatting with forge fmt"
+          COMMIT_HASH=$(git rev-parse HEAD)
+
+          # `printf` so the newline is interpreted; `echo "\n"` writes a literal \n
+          printf '# Github Actions automatically updated formatting with forge fmt\n%s\n' \
+            "$COMMIT_HASH" >> .git-blame-ignore-revs
+          git commit -am "Updated .git-blame-ignore-revs with commit $COMMIT_HASH"
+
+          git push origin "HEAD:${BRANCH}"
+        env:
+          BRANCH: ${{ steps.get-branch.outputs.branch }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ on:
 env:
   FOUNDRY_PROFILE: ci
 
+permissions:
+  contents: read
+
 jobs:
   check:
     strategy:
@@ -18,20 +21,31 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          # pinned rather than `nightly` so CI matches the reproducible-build claim
+          version: v1.7.1
 
-      - name: Lint
+      - name: Check formatting
         run: |
           echo "Running forge fmt --check"
-          if ! forge fmt --check; then 
-            echo "The linting check failed. You can fix it locally with 'forge fmt' and then push, or you can have a GitHub action take care of it for you by commenting '!fix' on the PR."
+          if ! forge fmt --check; then
+            echo "The formatting check failed. You can fix it locally with 'forge fmt' and then push, or you can have a GitHub action take care of it for you by commenting '!fix' on the PR."
+            exit 1
+          fi
+
+      # `forge lint` exits 0 even when it reports findings, so gate on its output
+      - name: Lint
+        run: |
+          set -euo pipefail
+          forge lint --severity high --severity med 2>&1 | tee lint.log
+          if grep -qE '^(warning|error)\[' lint.log; then
+            echo "forge lint reported findings above. Fix them, or add a"
+            echo "'// forge-lint: disable-next-line(<id>)' comment with a justification."
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,12 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+# matches the [profile.ci] section in foundry.toml (profile names are case-sensitive)
 env:
   FOUNDRY_PROFILE: ci
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check:
@@ -21,25 +22,24 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          # pinned rather than `nightly` so CI matches the reproducible-build claim
+          version: v1.7.1
 
       - name: Run Forge build
+        id: build
         run: |
           forge --version
           forge build --sizes
-        id: build
-        # don't fail if contract sizes are too large; tests will fail next if compilation failed
+        # don't fail on oversized contracts; tests below still catch build errors
         continue-on-error: true
 
       - name: Run Forge tests
-        run: |
-          FOUNDRY_PROFILE=CI forge test -vvv
         id: test
+        run: forge test -vvv

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ docs/
 
 # Dotenv file
 .env
+.env.*
 
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ forge init --template lazertechnologies/lazerforge --branch minimal <project_nam
 - Stablecoin Starter: 🚧 coming soon
 - Cross-Chain starter: 🚧 coming soon
 
-1. Build the project:
+3. Build the project:
 
 ```bash
 forge build

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 # update solc values if needed for compatability with older contracts
 auto_detect_solc = false
-solc = '0.8.28'
+solc = '0.8.36'
 # pin the EVM version explicitly rather than inheriting whatever the installed
 # forge version defaults to, so builds stay reproducible across toolchains
 evm_version = 'prague'

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,9 @@
 # update solc values if needed for compatability with older contracts
 auto_detect_solc = false
 solc = '0.8.28'
+# pin the EVM version explicitly rather than inheriting whatever the installed
+# forge version defaults to, so builds stay reproducible across toolchains
+evm_version = 'prague'
 src = "src"
 out = "out"
 libs = ["lib"]
@@ -32,20 +35,25 @@ bytecode_hash = 'none'
 cbor_metadata = false
 # grant access to read via_ir-out by default, if necessary
 fs_permissions = [{ access = "read", path = "./via_ir-out" }]
-# etherscan currently does not support contracts with more than 10 million optimizer runs;
-# bytecode is typically unaffected past ~1 million runs anyway
-optimizer_runs = 99_999_999
+# etherscan does not support verifying contracts compiled with more than 10 million
+# optimizer runs, so stay under that ceiling. Bytecode is typically unaffected past
+# ~1 million runs anyway. Lower this if you are near the 24KB contract size limit.
+optimizer = true
+optimizer_runs = 9_999_999
 
 [rpc_endpoints]
 sepolia = "${SEPOLIA_RPC_URL}"
 mainnet = "${ETHEREUM_RPC_URL}"
 base = "${BASE_RPC_URL}"
 base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
+anvil = "http://127.0.0.1:8545"
 
+# every network with an [rpc_endpoints] entry needs a matching entry here to verify
 [etherscan]
-ethereum = { key = "${ETHERSCAN_API_KEY}"}
-base = { key = "${BASESCAN_API_KEY}"}
-base_sepolia = { key = "${BASESCAN_API_KEY}"}
+mainnet = { key = "${ETHERSCAN_API_KEY}" }
+sepolia = { key = "${ETHERSCAN_API_KEY}" }
+base = { key = "${BASESCAN_API_KEY}" }
+base_sepolia = { key = "${BASESCAN_API_KEY}" }
 anvil = { key = "" }
 
 # via_ir pipeline is very slow - use a separate profile to pre-compile and then use vm.getCode to deploy
@@ -56,8 +64,10 @@ test = 'src'
 out = 'via_ir-out'
 
 # offload bulk of fuzz runs to CI
-[profile.CI.fuzz]
-fuzz_runs = 1024
+# NOTE: profile names are matched case-sensitively, keep this lowercase to match
+# the FOUNDRY_PROFILE value set by the GitHub Actions workflows
+[profile.ci.fuzz]
+runs = 1024
 
 [profile.ffi]
 ffi = true
@@ -75,9 +85,8 @@ optimizer = true
 optimizer_runs = 1000000
 via_ir = true
 
-# Local anvil profile
+# Local anvil profile - faster compiles for the local iterate/deploy loop
 [profile.anvil]
-evm_version = 'prague'
 optimizer = true
 optimizer_runs = 500_000
 
@@ -88,23 +97,23 @@ optimizer_runs = 500_000
 [profile.anvil.fuzz]
 runs = 64
 
-# Broadcast configuration - write to ./broadcast by default on scripts
-[profile.anvil.broadcast]
-retries = 10
-retries_delay_ms = 500
+# NOTE: there is no broadcast-retry config key. `broadcast` is a path string (the
+# output directory), so it cannot take a table. Verification attempts are tuned with
+# CLI flags instead:
+#   forge script script/Deploy.s.sol --rpc-url anvil --broadcast --retries 10 --delay 5
 
 # If you use forked anvil often, set a default fork here (optional)
 # [profile.anvil.rpc_storage_caching]
 # chains = ["anvil"]
 
-# Permissions for scripts that need artifacts/IO locally (inherits your default, add more if needed)
-[profile.anvil.fs_permissions]
-# carry over the via_ir read permission
-# additional example:
-# { access = "read-write", path = "./broadcast" }
+# Extra IO permissions for local scripts. `fs_permissions` is an array of tables and
+# fully replaces the default profile's value, so repeat any entries you still need:
+# fs_permissions = [
+#     { access = "read", path = "./via_ir-out" },
+#     { access = "read-write", path = "./broadcast" },
+# ]
 
-# Gas reporting locally (optional)
-[profile.anvil.gas_reports]
-# contracts = ["MyContract","AnotherContract"]
+# Gas reporting locally (optional). `gas_reports` is an array of contract names:
+# gas_reports = ["MyContract", "AnotherContract"]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/lazerTutorial/profiles.md
+++ b/lazerTutorial/profiles.md
@@ -18,7 +18,7 @@ LazerForge comes packaged with several pre-configured profiles:
 ### Default Profile
 
 ```bash
-forge build --profile default
+FOUNDRY_PROFILE=default forge build
 # or simply
 forge build
 ```
@@ -32,7 +32,7 @@ The default profile is used when no profile is specified. It includes:
 ### Gas Optimization Profile
 
 ```bash
-forge build --profile gas
+FOUNDRY_PROFILE=gas forge build
 ```
 
 Use this profile when you want to:
@@ -44,7 +44,7 @@ Use this profile when you want to:
 ### CI Fuzz Testing Profile
 
 ```bash
-forge test --profile CI.fuzz
+FOUNDRY_PROFILE=ci forge test
 ```
 
 This profile is designed for CI environments with:
@@ -56,7 +56,7 @@ This profile is designed for CI environments with:
 ### Via-IR Profile
 
 ```bash
-forge build --profile via_ir
+FOUNDRY_PROFILE=via_ir forge build
 ```
 
 Use this profile when:
@@ -68,7 +68,7 @@ Use this profile when:
 ### FFI Profile
 
 ```bash
-forge test --profile ffi
+FOUNDRY_PROFILE=ffi forge test
 ```
 
 For tests that require:
@@ -79,22 +79,23 @@ For tests that require:
 
 ## How to Use Profiles
 
-### 1. Using Command Line Flags
+### 1. Per-command
 
-The most common way to use profiles is with the `--profile` flag:
+`forge` has no `--profile` flag. Select a profile by setting the
+`FOUNDRY_PROFILE` environment variable for a single command:
 
 ```bash
 # Build with gas optimization
-forge build --profile gas
+FOUNDRY_PROFILE=gas forge build
 
 # Run tests with CI settings
-forge test --profile CI.fuzz
+FOUNDRY_PROFILE=ci forge test
 
 # Deploy with via-IR
-forge script script/Deploy.s.sol:DeployScript --profile via_ir
+FOUNDRY_PROFILE=via_ir forge script script/Deploy.s.sol:DeployScript
 ```
 
-### 2. Using Environment Variables
+### 2. For an entire shell session
 
 You can set a profile for all commands in your current shell:
 
@@ -109,10 +110,10 @@ When deploying contracts:
 
 ```bash
 # Deploy with gas optimization
-forge script script/Deploy.s.sol:DeployScript --profile gas --rpc-url $RPC_URL
+FOUNDRY_PROFILE=gas forge script script/Deploy.s.sol:DeployScript --rpc-url $RPC_URL
 
 # Deploy with via-IR for complex contracts
-forge script script/Deploy.s.sol:DeployScript --profile via_ir --rpc-url $RPC_URL
+FOUNDRY_PROFILE=via_ir forge script script/Deploy.s.sol:DeployScript --rpc-url $RPC_URL
 ```
 
 ## Common Use Cases
@@ -125,7 +126,7 @@ forge build
 forge test
 
 # When you need gas optimization
-forge build --profile gas
+FOUNDRY_PROFILE=gas forge build
 ```
 
 ### Testing
@@ -135,7 +136,7 @@ forge build --profile gas
 forge test
 
 # Thorough fuzz testing
-forge test --profile CI.fuzz
+FOUNDRY_PROFILE=ci forge test
 ```
 
 ### Deployment
@@ -145,7 +146,7 @@ forge test --profile CI.fuzz
 forge script script/Deploy.s.sol:DeployScript --rpc-url $RPC_URL
 
 # Gas-optimized deployment
-forge script script/Deploy.s.sol:DeployScript --profile gas --rpc-url $RPC_URL
+FOUNDRY_PROFILE=gas forge script script/Deploy.s.sol:DeployScript --rpc-url $RPC_URL
 ```
 
 ## Creating Your Own Profiles

--- a/sample.env
+++ b/sample.env
@@ -15,11 +15,15 @@ export FOUNDRY_FUZZ_RUNS=128
 
 ## DEPLOYING STUFF
 
+## prefer an encrypted keystore over a plaintext key for anything holding real funds:
+##   cast wallet import deployer --interactive
+##   forge script script/Deploy.s.sol --account deployer --rpc-url mainnet --broadcast
 export DEPLOYER_PRIVATE_KEY='<your_private_key>'
 
+## these names must match the ${...} placeholders in foundry.toml
 ## you can get RPC endpoints from alchemy, infura, or getblocks.io
 export SEPOLIA_RPC_URL='<your_rpc_endpoint>'
-export ETH_RPC_URL='<your_rpc_endpoint>'
+export ETHEREUM_RPC_URL='<your_rpc_endpoint>'
 export BASE_RPC_URL='<your_rpc_endpoint>'
 export BASE_SEPOLIA_RPC_URL='<your_rpc_endpoint>'
 

--- a/src/BalanceManager.sol
+++ b/src/BalanceManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "openzeppelin/contracts/security/ReentrancyGuard.sol";
 
@@ -12,6 +13,10 @@ import {ReentrancyGuard} from "openzeppelin/contracts/security/ReentrancyGuard.s
  * @notice Users can claim their balance of any token at any time.
  */
 contract BalanceManager is Ownable, ReentrancyGuard {
+    // tokens like USDT do not return a bool from transfer/transferFrom, and others
+    // return false instead of reverting. SafeERC20 handles both.
+    using SafeERC20 for IERC20;
+
     mapping(address => bool) public admins;
     mapping(address => mapping(address => uint256)) public balances;
     mapping(address => uint256) public totalBalances;
@@ -123,7 +128,7 @@ contract BalanceManager is Ownable, ReentrancyGuard {
         if (totalBalances[token] == 0) {
             allTokens.push(token);
         }
-        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
         emit Funded(token, amount);
     }
 
@@ -139,7 +144,7 @@ contract BalanceManager is Ownable, ReentrancyGuard {
         balances[msg.sender][token] = 0;
         totalBalances[token] -= balance;
         emit BalanceClaimed(msg.sender, token, balance);
-        IERC20(token).transfer(msg.sender, balance);
+        IERC20(token).safeTransfer(msg.sender, balance);
     }
 
     /**
@@ -156,7 +161,7 @@ contract BalanceManager is Ownable, ReentrancyGuard {
                 balances[msg.sender][token] = 0;
                 totalBalances[token] -= balance;
                 emit BalanceClaimed(msg.sender, token, balance);
-                IERC20(token).transfer(msg.sender, balance);
+                IERC20(token).safeTransfer(msg.sender, balance);
             }
         }
     }
@@ -175,7 +180,7 @@ contract BalanceManager is Ownable, ReentrancyGuard {
         uint256 availableAmount = IERC20(token).balanceOf(address(this)) - totalBalances[token];
         require(amount <= availableAmount, "Insufficient excess token balance");
 
-        IERC20(token).transfer(to, amount);
+        IERC20(token).safeTransfer(to, amount);
         emit TokensWithdrawn(token, amount, to);
     }
 

--- a/src/InflationToken.sol
+++ b/src/InflationToken.sol
@@ -44,6 +44,9 @@ contract InflationToken is ERC20, ERC20Burnable, Ownable {
      * @param to The address of the target account
      */
     function mint(address to) external onlyOwner {
+        // `block.timestamp` is safe here because the gate is a 365 day window; the
+        // seconds of drift a validator can introduce cannot meaningfully move it
+        // forge-lint: disable-next-line(block-timestamp)
         if (block.timestamp < mintingAllowedAfter) {
             revert MintingDateNotReached();
         }

--- a/test/InflationToken.t.sol
+++ b/test/InflationToken.t.sol
@@ -77,7 +77,7 @@ contract InflationTokenTest is Test {
     function test_recoverTokens() public {
         vm.warp(block.timestamp + 365 days);
         _token.mint(_owner);
-        _token.transfer(address(_token), _token.MINT_CAP());
+        assertTrue(_token.transfer(address(_token), _token.MINT_CAP()), "transfer to token contract failed");
 
         uint256 contractBalanceBefore = _token.balanceOf(address(_token));
         console.log("Contract balance before recovery:", contractBalanceBefore);
@@ -121,7 +121,7 @@ contract InflationTokenTest is Test {
         console.log("Testing Token Transfers");
         uint256 ownerBalanceBefore = _token.balanceOf(_owner);
         console.log("Owner balance before transfer:", ownerBalanceBefore);
-        _token.transfer(_user, 100);
+        assertTrue(_token.transfer(_user, 100), "transfer to user failed");
         console.log("Transferred 100 tokens to user");
         assertEq(_token.balanceOf(_user), 100);
         console.log("User balance after transfer:", _token.balanceOf(_user));

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -6,6 +6,8 @@ contract Utils {
         payload = new bytes(length);
 
         for (uint256 i; i < payload.length; ++i) {
+            // casting to 'uint8' is safe because `i % 256` is always in [0, 255]
+            // forge-lint: disable-next-line(unsafe-typecast)
             payload[i] = bytes1(uint8(i % 256));
         }
     }
@@ -21,6 +23,8 @@ contract Utils {
         message = new bytes(length);
 
         for (uint256 i; i < length; ++i) {
+            // casting to 'uint8' is safe because `i % 256` is always in [0, 255]
+            // forge-lint: disable-next-line(unsafe-typecast)
             message[i] = bytes1(uint8(i % 256));
         }
     }


### PR DESCRIPTION
## Description

Fixes a set of bugs found by auditing the config, workflows, and docs against the installed toolchain (forge 1.7.1). Every item below was reproduced before being fixed, and the fix verified after. Per [CONTRIBUTING](../blob/main/CONTRIBUTING.md) this targets `main`; the changes to `foundry.toml`, `.gitignore`, and `sample.env` will need a follow-up sync to `minimal`.

### `foundry.toml`

**`[profile.anvil]` failed to load at all.** `broadcast`, `fs_permissions`, and `gas_reports` were written as TOML tables, but they are a path string, an array of tables, and an array of strings respectively:

```
$ FOUNDRY_PROFILE=anvil forge config
Error: failed to extract foundry config:
foundry config error: invalid type: found map, expected path string for setting `broadcast`
```

There is no broadcast-retry config key at all — `retries`/`delay` are `forge script` verification flags. Replaced the invalid tables with commented examples in the correct shape.

**The CI fuzz override never applied.** `[profile.CI.fuzz]` used `fuzz_runs`; the key is `runs`. Forge printed `Warning: Found unknown fuzz_runs config key` on *every* invocation, and `FOUNDRY_PROFILE=CI forge config` resolved `runs = 256`, the default. Renamed to lowercase `[profile.ci]` so it matches the `FOUNDRY_PROFILE` value the workflows set. Now resolves to 1024.

**`optimizer_runs` contradicted its own comment** — the comment says Etherscan cannot verify above 10 million runs, the value was 99,999,999. Now 9,999,999, with `optimizer` set explicitly rather than inferred.

**Missing config:** `sepolia` had an RPC endpoint but no `[etherscan]` entry, and `anvil` had an Etherscan entry but no RPC endpoint. Added both. Also pinned `evm_version` explicitly instead of inheriting whatever the installed forge defaults to.

### `sample.env`

Exported `ETH_RPC_URL` while `foundry.toml` reads `${ETHEREUM_RPC_URL}`, so mainnet forking silently failed for every new user. Also added a pointer to `cast wallet import` over a plaintext key, and widened `.gitignore` to `.env.*`.

### Workflows

**`branch-consistency.yml` has never compared anything.** It read files with `git show main:"$file"`, but `actions/checkout` only creates a local branch for the ref it checked out — `main` and `minimal` exist only as remote-tracking refs. Both reads failed, both fell through to `|| echo ""`, and the job compared `""` to `""`. It is green right now despite `foundry.toml` having genuinely drifted between the branches.

It was also unworkable as designed: it byte-compared `foundry.toml`, which `minimal` intentionally omits the Uniswap remappings from, so that comparison can never pass. And since CONTRIBUTING documents a merge-to-`main`-then-sync flow, drift is expected at any given moment, so a blocking equality gate contradicts the documented process. The job now **reports** drift to the step summary rather than failing, and points at #26. Worth a look during review — this is the one judgement call rather than a mechanical fix.

**`fix-lint.yml` was broken and exploitable.**

- `echo ::set-output` has been disabled by GitHub → `$GITHUB_OUTPUT`.
- `if: github.event.issue.pull_request && ${{ ... }}` mixed bare and interpolated expression syntax.
- No permission check, so **any** user could trigger a job holding a `contents: write` token by commenting `!fix`. Now gated on `author_association`.
- Fork PRs are detected and skipped with a notice instead of failing at `git push` (GITHUB_TOKEN cannot push to a fork).
- `echo "...\n$COMMIT_HASH"` wrote a literal `\n` into `.git-blame-ignore-revs` → `printf`.

**Across all workflows:** pinned `foundry-toolchain` to `v1.7.1` instead of `nightly` (which contradicted the README's reproducible-build claim), bumped `actions/checkout` to v4, narrowed `permissions` to `contents: read`, dropped the `ref: github.head_ref` checkout that breaks on fork PRs, and removed the `FOUNDRY_PROFILE=CI` step override. Added `forge lint` to the lint workflow — it exits 0 even when it reports findings, so the step greps its output to decide.

### Contracts

`forge lint` reported six findings, none wired into CI. Four are real: `BalanceManager` ignored `transfer`/`transferFrom` return values. Tokens like USDT return no data, and others return `false` rather than reverting, so `claim` could zero out a user's recorded balance while the transfer silently did nothing. Switched to OpenZeppelin's `SafeERC20`.

The two test-side `transfer` calls now assert their return value, which also makes those tests actually verify the transfer succeeded. The `unsafe-typecast` and `block.timestamp` findings are safe by construction and carry a `forge-lint: disable-next-line` with the justification.

### Toolchain

`solc` was pinned to 0.8.28 with `auto_detect_solc = false`, so every build used a compiler roughly nine months behind. Bumped to **0.8.36**, the current release. All source pragmas are `^0.8.4`/`^0.8.20`/`^0.8.24`, so nothing else needed changing — build, tests, lint, and fmt are all clean on the new compiler.

`foundry-toolchain` is pinned to **v1.7.1**, which is the latest stable foundry release, so the pin added above is already current.

Left `evm_version` at `prague`: forge 1.7.1 still defaults to it, so it is what the toolchain treats as current. `osaka` compiles cleanly if you'd rather move now — say the word.

Dependency versions are a separate matter and are **not** touched here. `lib/` turns out not to be submodules at all (filed separately), so nothing under it can be updated with `git submodule update` or `forge update` today. OpenZeppelin is stuck at 4.9.2 and GitHub currently reports 223 Dependabot alerts against the vendored trees.

### Docs

`lazerTutorial/profiles.md` taught `forge build --profile <name>` in 13 places. `forge` has no `--profile` flag:

```
$ forge test --profile ci
error: unexpected argument '--profile' found
```

Rewrote every example to use `FOUNDRY_PROFILE=<name> forge ...`. Three also referenced `--profile CI.fuzz`, which is a config section path rather than a profile name. README Quick Start numbered its steps 1, 2, 1.

## Changes

- [x] `foundry.toml`: repair `[profile.anvil]`, fix the dead CI fuzz override, resolve the optimizer contradiction, fill in missing network config
- [x] `sample.env`: fix the RPC env var name mismatch
- [x] `branch-consistency.yml`: make it actually read both branches; report instead of block
- [x] `fix-lint.yml`: fix `set-output`, `if` syntax, and the unguarded `contents: write` trigger
- [x] all workflows: pin toolchain, bump actions, narrow permissions
- [x] `BalanceManager`: use `SafeERC20`
- [x] clear all `forge lint` findings and gate on them in CI
- [x] `profiles.md`: replace the nonexistent `--profile` flag
- [x] bump pinned `solc` 0.8.28 → 0.8.36

## Verification

```
forge fmt --check                        clean
forge lint                               0 findings (was 6)
forge build                              successful
forge test                               27 passed, 0 failed (on solc 0.8.36)
FOUNDRY_PROFILE=<p> forge config         all 6 profiles load (anvil previously errored)
FOUNDRY_PROFILE=ci forge config          fuzz.runs = 1024 (was 256)
```

No unknown-key warnings remain. Workflow YAML parses.

## Not included

- `BalanceManager`'s constructor takes `initialOwner` and ignores it — `Ownable()` in OZ 4.9 sets the owner to `msg.sender`, so deploying through a script or factory assigns ownership to the deployer, not the requested address. Left out to keep this PR to verified-and-reproduced bugs; filed separately.
- Lowering the default `optimizer_runs` to something conventional (200–1000). ~10M is still an unusual default that inflates bytecode and raises the odds of hitting the 24KB limit, but changing it is a positioning decision, not a bug fix.

## Checklist

- [x] `forge fmt`
- [x] `forge test`
