### PR TITLE
🔧 replace root helper scripts with a justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ LazerForge is a batteries included template with the following configurations:
 - `forge fmt` configured as the default formatter for VSCode projects
 - Github Actions workflows that run `forge fmt --check` and `forge test` on every push and PR
   - A separate action to automatically fix formatting issues on PRs by commenting `!fix` on the PR
+- A `justfile` with the common Foundry recipes (`just --list`)
 - A pre-configured, but still minimal `foundry.toml`
   - multiple profiles for various development and testing scenarios (see [LazerForge Profiles](lazerTutorial/profiles.md))
   - high optimizer settings by default for gas-efficient smart contracts
@@ -99,29 +100,20 @@ import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Po
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 ```
 
-## Gas Snapshots
+## Commands
 
-Forge can generate gas snapshots for all test functions to see how much gas contracts will consume, or to compare gas usage before and after optimizations.
-
-```shell
-forge snapshot
-```
-
-## Coverage Reports
-
-If you plan on generating coverage reports, you'll need to install [`lcov`](https://github.com/linux-test-project/lcov) as well.
-
-On macOS, you can do this with the following command:
+Common tasks live in the `justfile`. [Install just](https://github.com/casey/just#installation), then run `just` (or `just --list`) to see them:
 
 ```bash
-brew install lcov
+just build       # forge build
+just test        # forge test
+just fmt         # forge fmt
+just lint        # forge lint
+just snapshot    # forge snapshot
+just cov         # coverage summary + HTML report
 ```
 
-To generate reports, run
-
-```bash
-./coverage-report
-```
+Recipes accept extra flags (`just test --match-test test_Deposit`). `just cov` needs [`lcov`](https://github.com/linux-test-project/lcov) (`brew install lcov` on macOS) and uses a `[profile.coverage]` with the optimizer off so instrumentation does not hit "stack too deep".
 
 ## Documentation
 

--- a/coverage-report
+++ b/coverage-report
@@ -1,3 +1,0 @@
-# "Forge coverage" - Generate a coverage summary report as well as an lcov.info, and generate an HTML report from the lcov.info
-# Requires the lcov package to be installed
-forge coverage --report summary --report lcov && genhtml lcov.info -o coverage --branch

--- a/foundry.toml
+++ b/foundry.toml
@@ -99,6 +99,11 @@ optimizer = true
 optimizer_runs = 1000000
 via_ir = true
 
+# Coverage instrumentation fights the default 9_999_999 optimizer runs and can
+# hit "stack too deep". `just cov` sets FOUNDRY_PROFILE=coverage to use this.
+[profile.coverage]
+optimizer = false
+
 # Local anvil profile - faster compiles for the local iterate/deploy loop
 [profile.anvil]
 optimizer = true

--- a/justfile
+++ b/justfile
@@ -1,0 +1,31 @@
+# LazerForge command runner. `just` (or `just --list`) prints this list.
+# https://github.com/casey/just
+
+set default-list := true
+
+# Compile contracts
+build *args:
+    forge build {{args}}
+
+# Run tests
+test *args:
+    forge test {{args}}
+
+# Format Solidity
+fmt *args:
+    forge fmt {{args}}
+
+# Lint Solidity
+lint *args:
+    forge lint {{args}}
+
+# Write gas snapshots
+snapshot *args:
+    forge snapshot {{args}}
+
+# Coverage summary + HTML report (needs `lcov`: `brew install lcov`)
+cov:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    FOUNDRY_PROFILE=coverage forge coverage --report summary --report lcov
+    genhtml lcov.info -o coverage --branch

--- a/lazerTutorial/profiles.md
+++ b/lazerTutorial/profiles.md
@@ -65,6 +65,16 @@ Use this profile when:
 - need to use the via-IR pipeline
 - dealing with large contract sizes
 
+### Coverage Profile
+
+```bash
+FOUNDRY_PROFILE=coverage forge coverage
+# or
+just cov
+```
+
+Coverage instrumentation with the default 9_999_999 optimizer runs can hit "stack too deep". This profile turns the optimizer off. `just cov` selects it automatically and also writes the HTML report.
+
 ### FFI Profile
 
 ```bash

--- a/lazerTutorial/setup.md
+++ b/lazerTutorial/setup.md
@@ -9,6 +9,7 @@ Before starting with LazerForge, make sure you have the following installed:
 1. Git
 2. Node.js (for development tools)
 3. Code editor (VSCode + Solidity extension recommended)
+4. [`just`](https://github.com/casey/just#installation) (optional — `just --list` runs the common Foundry recipes in the `justfile`)
 
 ## Installation
 
@@ -82,6 +83,7 @@ LazerForge comes pre-configured with VSCode settings:
 ├── script/                     # example scripts
 ├── .github/                    # GitHub Actions workflows
 ├── lazerTutorial/              # LazerForge tutorial
+├── justfile                    # common forge recipes (`just --list`)
 └── foundry.toml                # foundry config
 ```
 

--- a/lazerTutorial/testing.md
+++ b/lazerTutorial/testing.md
@@ -32,23 +32,25 @@ Forge can generate gas snapshots for all test functions to see how much gas cont
 
 ```shell
 forge snapshot
+# or
+just snapshot
 ```
 
 ## Coverage Reports
 
-If you plan on generating coverage reports, you'll need to install [`lcov`](https://github.com/linux-test-project/lcov) as well.
-
-On macOS, you can do this with the following command:
+Coverage reports need [`just`](https://github.com/casey/just#installation) and [`lcov`](https://github.com/linux-test-project/lcov). On macOS:
 
 ```bash
-brew install lcov
+brew install just lcov
 ```
 
-To generate reports, run
+Then run:
 
 ```bash
-./coverage-report
+just cov
 ```
+
+That uses `[profile.coverage]` in `foundry.toml` (optimizer off) so instrumentation does not hit "stack too deep" against the template's high `optimizer_runs`. It writes a summary, `lcov.info`, and an HTML report under `coverage/`.
 
 ## Writing Tests
 


### PR DESCRIPTION
## Description

Two extensionless wrappers sat at the repo root (`coverage-report`, and previously `reinit-submodules`) with no `--help` and nothing listing them but the README. This replaces them with a `justfile` so `just --list` documents the common Foundry recipes, and adds a `[profile.coverage]` with the optimizer off so `forge coverage` does not hit "stack too deep" against the template's 9_999_999 `optimizer_runs`.

Fixes #34.

## Changes

- [x] Add a `justfile` with `build`, `test`, `fmt`, `lint`, `snapshot`, and `cov` recipes
- [x] Add `[profile.coverage]` (`optimizer = false`) and point `just cov` at it
- [x] Delete `coverage-report`
- [x] Shrink the README into a Commands section; update the testing, setup, and profiles tutorials

## Notes for review

- **`reinit-submodules` was not ported.** It existed only to recover from submodule desync when switching `main`/`minimal`. Soldeer (#41) already removed it, which is what #34 asked for if that migration landed.
- **Targets `main` first**, per CONTRIBUTING.md. The `justfile` is core tooling, not tutorial content, so it should stay in the generated `minimal` tree once #26 lands.
- Does not touch variant-generation files or the `feat/generate-variant-branches` work.

## Verification

- `just --list` prints the recipes
- `just build` and `just test` — 29 tests pass
- `just cov` writes the summary, `lcov.info`, and HTML under `coverage/` without "stack too deep"
- `just fmt` / `forge fmt` clean

## Checklist

- [x] `forge fmt`
- [x] `forge test`

Made with [Cursor](https://cursor.com)