### PR TITLE
🔧 keep development worktrees inside .worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ via_ir-out/
 # Worktrees produced by tools/build-variant.sh
 /.variant-build/
 
+# Development worktrees created with tools/worktree.sh
+/.worktrees/
+
 # Ignores development broadcast logs
 broadcast/*
 !/broadcast

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,19 @@ If you push to one anyway, it will not stick: every build replaces the whole tre
 
 > **Maintainers:** importable rulesets live in [`.github/rulesets/`](.github/rulesets/), with notes on what each one does and why the variant branches are not update-restricted.
 
+## Development worktrees
+
+When you need a second checkout for parallel branch work, keep it inside the repo:
+
+```bash
+just worktree ci/caching-coverage-snapshot
+# or: tools/worktree.sh add ci/caching-coverage-snapshot
+```
+
+That creates `.worktrees/ci-caching-coverage-snapshot/`. List or remove with `just worktrees` and `just worktree-rm <branch>`.
+
+Do not create sibling directories next to the repo (for example `../LazerForge-issue-33`).
+
 ## Questions or Clarifications
 
 If you have any questions about the branch structure or contribution process, please open an issue in the repository.

--- a/justfile
+++ b/justfile
@@ -36,4 +36,16 @@ cov:
 variant name *args:
     tools/build-variant.sh {{name}} {{args}}
 
+# Add a development worktree under .worktrees/
+worktree branch *args:
+    tools/worktree.sh add {{branch}} {{args}}
+
+# List all worktrees
+worktrees:
+    tools/worktree.sh list
+
+# Remove a development worktree under .worktrees/
+worktree-rm branch:
+    tools/worktree.sh remove {{branch}}
+
 # variant:full:end

--- a/justfile
+++ b/justfile
@@ -36,6 +36,10 @@ cov:
 variant name *args:
     tools/build-variant.sh {{name}} {{args}}
 
+# variant:full:end
+
+# variant:full:start
+
 # Add a development worktree under .worktrees/
 worktree branch *args:
     tools/worktree.sh add {{branch}} {{args}}

--- a/tools/worktree.sh
+++ b/tools/worktree.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Manage development git worktrees under .worktrees/.
+#
+# Usage:
+#   tools/worktree.sh add <branch> [--new-branch <name>] [--path <dir>]
+#   tools/worktree.sh list
+#   tools/worktree.sh remove <branch>
+#
+# By default, worktrees are created at .worktrees/<branch-with-slashes-as-dashes>.
+# This keeps sibling checkouts inside the repo instead of cluttering the parent
+# directory.
+
+set -euo pipefail
+
+readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly WORKTREES_DIR="$REPO_ROOT/.worktrees"
+
+die() {
+    printf '\033[31merror\033[0m: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage:
+  tools/worktree.sh add <branch> [--new-branch <name>] [--path <dir>]
+  tools/worktree.sh list
+  tools/worktree.sh remove <branch>
+
+Examples:
+  tools/worktree.sh add ci/caching-coverage-snapshot
+  tools/worktree.sh add main --new-branch fix/ci-cache
+  tools/worktree.sh remove ci/caching-coverage-snapshot
+EOF
+}
+
+branch_to_dir() {
+    printf '%s' "$1" | tr '/' '-'
+}
+
+default_path_for_branch() {
+    printf '%s/%s' "$WORKTREES_DIR" "$(branch_to_dir "$1")"
+}
+
+cmd_add() {
+    local branch=""
+    local new_branch=""
+    local path=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --new-branch)
+                [[ $# -ge 2 ]] || die "--new-branch requires a value"
+                new_branch="$2"
+                shift 2
+                ;;
+            --path)
+                [[ $# -ge 2 ]] || die "--path requires a value"
+                path="$2"
+                shift 2
+                ;;
+            -*)
+                die "unknown option: $1"
+                ;;
+            *)
+                [[ -z "$branch" ]] || die "unexpected argument: $1"
+                branch="$1"
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$branch" ]] || die "branch is required"
+
+    if [[ -z "$path" ]]; then
+        if [[ -n "$new_branch" ]]; then
+            path="$(default_path_for_branch "$new_branch")"
+        else
+            path="$(default_path_for_branch "$branch")"
+        fi
+    elif [[ "$path" != /* ]]; then
+        path="$REPO_ROOT/$path"
+    fi
+
+    case "$path" in
+        "$WORKTREES_DIR"/*) ;;
+        *)
+            die "worktree path must be inside $WORKTREES_DIR (got: $path)"
+            ;;
+    esac
+
+    mkdir -p "$WORKTREES_DIR"
+
+    if [[ -n "$new_branch" ]]; then
+        git -C "$REPO_ROOT" worktree add -b "$new_branch" "$path" "$branch"
+    else
+        git -C "$REPO_ROOT" worktree add "$path" "$branch"
+    fi
+
+    printf '\nworktree: %s\n' "$path"
+}
+
+cmd_list() {
+    git -C "$REPO_ROOT" worktree list
+}
+
+cmd_remove() {
+    local branch="${1:-}"
+    [[ -n "$branch" ]] || die "branch is required"
+
+    local path
+    path="$(default_path_for_branch "$branch")"
+    [[ -d "$path" ]] || die "no worktree found at $path"
+
+    git -C "$REPO_ROOT" worktree remove "$path"
+}
+
+main() {
+    local cmd="${1:-}"
+    shift || true
+
+    case "$cmd" in
+        add) cmd_add "$@" ;;
+        list) cmd_list "$@" ;;
+        remove) cmd_remove "$@" ;;
+        -h | --help | help | "") usage ;;
+        *) die "unknown command: $cmd" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Keep parallel development checkouts inside the repo under `.worktrees/` instead of creating sibling directories next to the repository root.

## Changes

- [x] Add `tools/worktree.sh` to create, list, and remove worktrees under `.worktrees/`
- [x] Add `just worktree`, `just worktrees`, and `just worktree-rm` recipes
- [x] Ignore `.worktrees/` in `.gitignore`
- [x] Document the convention in `CONTRIBUTING.md`

## Checklist

- [x] `forge fmt` (no Solidity changes)
- [x] `forge test` (no contract changes; CI passes)