### PR TITLE
✨ Make keystore accounts the default deploy path and add DeployBase

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,55 @@
+name: Forge Examples
+
+# Demo contracts under examples/. Kept as its own workflow so variant/minimal can
+# drop the file entirely (see variants/minimal.yml) without stripping markers
+# out of test.yml — GITHUB_TOKEN cannot push unique workflow content.
+
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    env:
+      FOUNDRY_PROFILE: examples
+      # A job-level profile replaces `ci`, so [profile.ci.fuzz] no longer applies
+      # here - and the repo's only fuzz tests are in examples/. Set the campaign
+      # size directly so CI keeps running it at full depth.
+      FOUNDRY_FUZZ_RUNS: 1024
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-foundry
+
+      # the contracts big enough to approach the 24KB limit all live here, so
+      # this is where the size check earns its keep
+      - name: Build examples
+        run: forge build --sizes
+
+      - name: Test examples
+        run: forge test -vvv
+
+  gas:
+    name: Gas snapshot
+    runs-on: ubuntu-latest
+    env:
+      # Snapshot the example contracts — Counter gas is not interesting.
+      FOUNDRY_PROFILE: examples
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-foundry
+
+      # Fuzz and invariant tests are excluded: their gas depends on random
+      # inputs, so they cannot gate PRs. Update the committed snapshot with
+      # the same filter after a gas-affecting change.
+      - name: Check gas snapshot
+        run: forge snapshot --check --nmt 'test_fuzz|testFuzz|invariant'

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -57,9 +57,9 @@ jobs:
           set -euo pipefail
 
           forge fmt
-          # variant:full:start
-          FOUNDRY_PROFILE=examples forge fmt
-          # variant:full:end
+          if [ -d examples ]; then
+            FOUNDRY_PROFILE=examples forge fmt
+          fi
 
           if git diff --quiet; then
             echo "::notice::Formatting is already correct, nothing to fix."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,16 +30,18 @@ jobs:
 
       # `skip` in [profile.default] hides examples/ from fmt and lint, and the
       # examples profile hides src/. Neither tree is covered by one invocation,
-      # so both run. Keep these in step if a profile's paths change.
+      # so both run when examples/ is present. Detect at runtime rather than
+      # stripping with variant markers: GITHUB_TOKEN cannot push workflow files
+      # whose contents do not already exist on another branch.
       - name: Check formatting
         run: |
           set -euo pipefail
           echo "Running forge fmt --check"
           failed=0
           forge fmt --check || failed=1
-          # variant:full:start
-          FOUNDRY_PROFILE=examples forge fmt --check || failed=1
-          # variant:full:end
+          if [ -d examples ]; then
+            FOUNDRY_PROFILE=examples forge fmt --check || failed=1
+          fi
           if [ "$failed" -ne 0 ]; then
             echo "The formatting check failed. You can fix it locally with 'just fmt' and then push, or you can have a GitHub action take care of it for you by commenting '!fix' on the PR."
             exit 1
@@ -50,9 +52,9 @@ jobs:
         run: |
           set -euo pipefail
           forge lint --severity high --severity med 2>&1 | tee lint.log
-          # variant:full:start
-          FOUNDRY_PROFILE=examples forge lint --severity high --severity med 2>&1 | tee -a lint.log
-          # variant:full:end
+          if [ -d examples ]; then
+            FOUNDRY_PROFILE=examples forge lint --severity high --severity med 2>&1 | tee -a lint.log
+          fi
           if grep -qE '^(warning|error)\[' lint.log; then
             echo "forge lint reported findings above. Fix them, or add a"
             echo "'// forge-lint: disable-next-line(<id>)' comment with a justification."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,12 @@ jobs:
         id: test
         run: forge test -vvv
 
-  # variant:full:start
+  # Skip on variant/minimal (no examples/). Runtime `if` keeps this workflow
+  # identical across branches so variant publish can use GITHUB_TOKEN — GitHub
+  # rejects pushes of workflow content that does not already exist elsewhere.
   examples:
     name: Examples
+    if: hashFiles('examples/**/*.sol') != ''
     runs-on: ubuntu-latest
     env:
       FOUNDRY_PROFILE: examples
@@ -62,6 +65,7 @@ jobs:
 
   gas:
     name: Gas snapshot
+    if: hashFiles('examples/**/*.sol') != ''
     runs-on: ubuntu-latest
     env:
       # Snapshot the example contracts — Counter gas is not interesting.
@@ -76,7 +80,6 @@ jobs:
       # the same filter after a gas-affecting change.
       - name: Check gas snapshot
         run: forge snapshot --check --nmt 'test_fuzz|testFuzz|invariant'
-  # variant:full:end
 
   coverage:
     name: Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,50 +37,6 @@ jobs:
         id: test
         run: forge test -vvv
 
-  # Skip on variant/minimal (no examples/). Runtime `if` keeps this workflow
-  # identical across branches so variant publish can use GITHUB_TOKEN — GitHub
-  # rejects pushes of workflow content that does not already exist elsewhere.
-  examples:
-    name: Examples
-    if: hashFiles('examples/**/*.sol') != ''
-    runs-on: ubuntu-latest
-    env:
-      FOUNDRY_PROFILE: examples
-      # A job-level profile replaces `ci`, so [profile.ci.fuzz] no longer applies
-      # here - and the repo's only fuzz tests are in examples/. Set the campaign
-      # size directly so CI keeps running it at full depth.
-      FOUNDRY_FUZZ_RUNS: 1024
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/setup-foundry
-
-      # the contracts big enough to approach the 24KB limit all live here, so
-      # this is where the size check earns its keep
-      - name: Build examples
-        run: forge build --sizes
-
-      - name: Test examples
-        run: forge test -vvv
-
-  gas:
-    name: Gas snapshot
-    if: hashFiles('examples/**/*.sol') != ''
-    runs-on: ubuntu-latest
-    env:
-      # Snapshot the example contracts — Counter gas is not interesting.
-      FOUNDRY_PROFILE: examples
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/setup-foundry
-
-      # Fuzz and invariant tests are excluded: their gas depends on random
-      # inputs, so they cannot gate PRs. Update the committed snapshot with
-      # the same filter after a gas-affecting change.
-      - name: Check gas snapshot
-        run: forge snapshot --check --nmt 'test_fuzz|testFuzz|invariant'
-
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ broadcast/*
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 
+# Local anvil deployment records (chain id 31337)
+/deployments/31337.json
+
 # Docs
 docs/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,9 +75,11 @@ The name list is comma separated (`# variant:full,defi:start` keeps the region f
 Do **not** put marker regions in `.github/workflows/` files. Variant stripping
 would produce workflow contents that do not already exist on another branch, and
 `GITHUB_TOKEN` cannot push those (GitHub requires the `workflow` scope for unique
-workflow content). Keep shared workflows identical on every branch and gate
-examples-only steps with runtime checks instead (`[ -d examples ]` or
-`hashFiles('examples/**/*.sol') != ''`).
+workflow content). Keep shared workflows identical on every branch. Put examples-only
+jobs in their own workflow and add that path to the variant's `remove:` list (see
+`.github/workflows/examples.yml`). Inside a shared `run:` script, `[ -d examples ]`
+is fine — that is shell, not a job-level expression (`hashFiles` is not available in
+`jobs.<id>.if`).
 
 Markdown uses an HTML comment instead, so the marker does not render:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,13 @@ Structure the repo so this is usually enough. Demo contracts live under `example
 
 The name list is comma separated (`# variant:full,defi:start` keeps the region for both), and the marker lines are always stripped from generated output. Both `#` and `//` prefixes work, so this covers Solidity as well as TOML. A marker has to be alone on its line, so mentioning one in prose does nothing.
 
+Do **not** put marker regions in `.github/workflows/` files. Variant stripping
+would produce workflow contents that do not already exist on another branch, and
+`GITHUB_TOKEN` cannot push those (GitHub requires the `workflow` scope for unique
+workflow content). Keep shared workflows identical on every branch and gate
+examples-only steps with runtime checks instead (`[ -d examples ]` or
+`hashFiles('examples/**/*.sol') != ''`).
+
 Markdown uses an HTML comment instead, so the marker does not render:
 
 ```markdown

--- a/deployments/.gitkeep
+++ b/deployments/.gitkeep
@@ -1,0 +1,2 @@
+# Deploy scripts write addresses here as `<chainid>.json` (see script/utils/DeployBase.s.sol).
+# Keep this directory in git so the path exists in fresh clones; commit records you want shared.

--- a/foundry.toml
+++ b/foundry.toml
@@ -56,8 +56,11 @@ block_timestamp = 1689711647
 # don't pollute bytecode with metadata
 bytecode_hash = 'none'
 cbor_metadata = false
-# grant access to read via_ir-out by default, if necessary
-fs_permissions = [{ access = "read", path = "./via_ir-out" }]
+# via_ir-out for the via_ir profile; deployments/ for DeployBase's per-chain JSON records
+fs_permissions = [
+    { access = "read", path = "./via_ir-out" },
+    { access = "read-write", path = "./deployments" },
+]
 # etherscan does not support verifying contracts compiled with more than 10 million
 # optimizer runs, so stay under that ceiling. Bytecode is typically unaffected past
 # ~1 million runs anyway. Lower this if you are near the 24KB contract size limit.
@@ -152,7 +155,7 @@ runs = 64
 # NOTE: there is no broadcast-retry config key. `broadcast` is a path string (the
 # output directory), so it cannot take a table. Verification attempts are tuned with
 # CLI flags instead:
-#   forge script script/DeployCounter.s.sol --rpc-url anvil --broadcast --retries 10 --delay 5
+#   forge script script/DeployCounter.s.sol --account deployer --rpc-url anvil --broadcast --retries 10 --delay 5
 
 # If you use forked anvil often, set a default fork here (optional)
 # [profile.anvil.rpc_storage_caching]
@@ -162,6 +165,7 @@ runs = 64
 # fully replaces the default profile's value, so repeat any entries you still need:
 # fs_permissions = [
 #     { access = "read", path = "./via_ir-out" },
+#     { access = "read-write", path = "./deployments" },
 #     { access = "read-write", path = "./broadcast" },
 # ]
 

--- a/lazerTutorial/deployment.md
+++ b/lazerTutorial/deployment.md
@@ -40,55 +40,65 @@ forge soldeer install
 forge build
 ```
 
-Fill in necessary environment variables for the network you are deploying on. It's good practice to always deploy first to a testnet like Sepolia before deploying to a non-test network.
+Fill in the RPC URL (and any explorer API keys) for the network you are deploying on. It's good practice to always deploy first to a testnet like Sepolia before deploying to a non-test network.
 
 ```bash
 SEPOLIA_RPC_URL='https://eth-sepolia.g.alchemy.com/v2/demo'
-DEPLOYER_PRIVATE_KEY='<your_pk>'
 ```
 
-⚠️ **Follow proper `.env` and `.gitignore` practices to prevent leaked keys.**
+## Secure key handling (default: encrypted keystore)
+
+**Do not put private keys in `.env` for anything that holds real funds.** Import an encrypted keystore once, then pass it with `--account`:
+
+```bash
+cast wallet import deployer --interactive
+forge script script/DeployCounter.s.sol --account deployer --rpc-url sepolia --broadcast --verify
+```
+
+`cast wallet import` stores the key encrypted on disk under Foundry's keystore directory. `--account deployer` unlocks it for that run (you will be prompted for the password). Scripts in this template call `vm.startBroadcast()` with no key when `DEPLOYER_PRIVATE_KEY` is unset, so the CLI account is what signs.
+
+Deploy scripts also write the resulting address to `deployments/<chainid>.json` so later runs do not depend only on `broadcast/` logs.
+
+Demo contracts under `examples/` use the same helpers via `script/examples/` and need `FOUNDRY_PROFILE=examples` (or `just examples-build`).
+
+### CI / automation only: environment private key
+
+Headless pipelines that cannot unlock a keystore may set `DEPLOYER_PRIVATE_KEY` instead. Treat that as a CI secret, never as the default local workflow:
+
+```bash
+export DEPLOYER_PRIVATE_KEY='<ci_deployer_key>'
+forge script script/DeployCounter.s.sol --rpc-url sepolia --broadcast --verify
+```
+
+⚠️ **Follow proper `.env` and `.gitignore` practices. Never commit a real private key.**
 
 ## Deployment Scripts
 
-Deployments are handled through script files, written in Solidity and using the naming convention `Contract.s.sol`. You can run a script directly from your CLI
+Deployments are handled through script files, written in Solidity and using the naming convention `Contract.s.sol`. Shared broadcast, CREATE2, and deployment-record helpers live in `script/utils/DeployBase.s.sol` — extend that rather than reimplementing signing or JSON output.
+
+You can run a script directly from your CLI:
 
 ```bash
-forge script script/MyContract.s.sol:MyContractScript --rpc-url <your_rpc_url> --private-key <your_private_key> --chain-id <chain_id> -vv
+forge script script/DeployCounter.s.sol --account deployer --rpc-url sepolia -vv
 ```
 
-> 💡 It is best practice to keep all scripts related to a contract in a single script file, for example `MyToken` may have functions to `Deploy` and `Mint`. You can run a single function by appending the file name in the previous script like this `forge script script/MyScript.s.sol:MyFunction`.
+> 💡 It is best practice to keep all scripts related to a contract in a single script file, for example `MyToken` may have functions to `Deploy` and `Mint`. You can run a single function by appending the contract name like this: `forge script script/MyScript.s.sol:MyFunction`.
 
-Unless you include the `--broadcast` argument, the script will be run in a simulated environment. If you need to run the script live, use the `--broadcast` arg
+Unless you include the `--broadcast` argument, the script will be run in a simulated environment. If you need to run the script live, use the `--broadcast` arg.
 
 ⚠️ **Using `--broadcast` will initiate an onchain transaction, only use after thoroughly testing**
 
 ### Broadcast
 
 ```bash
-forge script script/MyContract.s.sol:MyContractScript --rpc-url <your_rpc_url> --private-key <your_private_key> --chain-id 1 -vv --broadcast
+forge script script/DeployCounter.s.sol --account deployer --rpc-url sepolia -vv --broadcast
 ```
 
-Additional arguments can specify the chain and verbosity of the script
+Additional arguments can specify verbosity and verification:
 
 ```bash
-forge script script/MyContract.s.sol:MyContractScript --rpc-url <your_rpc_url> --private-key <your_private_key> --chain-id 1 -vv
+forge script script/DeployCounter.s.sol --account deployer --rpc-url sepolia -vv --broadcast --verify
 ```
-
-## Secure Private Key Handling
-
-You can make a private key available to a script directly to prevent exposing it in the command line (recommended).
-
-⚠️ **NEVER place your private key in a script in plaintext, always use environment variables!**
-
-```js
-function run() public {
-    vm.startBroadcast(vm.envUint('PRIVATE_KEY'));
-    // rest of your code...
-}
-```
-
-Then run the `forge script` command without the private key arg.
 
 💡 **When deploying a new contract, you can use the `--verify` arg to verify the contract on deployment.**
 

--- a/sample.env
+++ b/sample.env
@@ -15,10 +15,12 @@ export FOUNDRY_FUZZ_RUNS=128
 
 ## DEPLOYING STUFF
 
-## prefer an encrypted keystore over a plaintext key for anything holding real funds:
-##   cast wallet import deployer --interactive
-##   forge script script/Deploy.s.sol --account deployer --rpc-url mainnet --broadcast
-export DEPLOYER_PRIVATE_KEY='<your_private_key>'
+# Default local path: encrypted keystore (do not put mainnet keys in this file).
+#   cast wallet import deployer --interactive
+#   forge script script/DeployCounter.s.sol --account deployer --rpc-url base --broadcast --verify
+#
+# CI / automation only — uncomment and inject via secrets, never commit a real value:
+# export DEPLOYER_PRIVATE_KEY='<ci_deployer_key>'
 
 ## these names must match the ${...} placeholders in foundry.toml
 ## you can get RPC endpoints from alchemy, infura, or getblocks.io

--- a/script/DeployCounter.s.sol
+++ b/script/DeployCounter.s.sol
@@ -1,13 +1,32 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
-import {Script, console} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
 import {Counter} from "../src/Counter.sol";
+import {DeployBase} from "./utils/DeployBase.s.sol";
 
-contract DeployCounter is Script {
+/**
+ * @title DeployCounter
+ * @notice Deploys the starter Counter under `src/`.
+ *
+ * Preferred (encrypted keystore):
+ *   cast wallet import deployer --interactive
+ *   forge script script/DeployCounter.s.sol --account deployer --rpc-url sepolia --broadcast --verify
+ *
+ * CI / automation (plaintext key in the environment):
+ *   forge script script/DeployCounter.s.sol --rpc-url sepolia --broadcast
+ *   # with DEPLOYER_PRIVATE_KEY set
+ *
+ * Simulate without broadcasting:
+ *   forge script script/DeployCounter.s.sol --sender <address> --fork-url $SEPOLIA_RPC_URL -vvvv
+ */
+contract DeployCounter is DeployBase {
     function run() public {
-        vm.broadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        _startBroadcast();
         Counter counter = new Counter();
+        _stopBroadcast();
+
+        _writeDeployment("Counter", address(counter));
         console.log("Counter deployed at:", address(counter));
     }
 }

--- a/script/examples/CrossChainDeploy.s.sol
+++ b/script/examples/CrossChainDeploy.s.sol
@@ -1,106 +1,70 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
-import "forge-std/Script.sol";
-import "forge-std/console.sol";
-import "solady/utils/LibString.sol";
-import "../../examples/BalanceManager.sol";
-
-interface ImmutableCreate2Factory {
-    function hasBeenDeployed(address deploymentAddress) external view returns (bool);
-
-    function findCreate2Address(bytes32 salt, bytes calldata initializationCode)
-        external
-        view
-        returns (address deploymentAddress);
-
-    function safeCreate2(bytes32 salt, bytes calldata initializationCode)
-        external
-        payable
-        returns (address deploymentAddress);
-}
+import {console} from "forge-std/console.sol";
+import {LibString} from "solady/utils/LibString.sol";
+import {BalanceManager} from "../../examples/BalanceManager.sol";
+import {DeployBase} from "../utils/DeployBase.s.sol";
 
 /**
  * @title CrossChainDeployScript
- * @notice This script deploys a contract to the same address regardless of
- *         which chain it's run on. Simulate running it by entering
- *         `FOUNDRY_PROFILE=examples forge script
- *         script/examples/CrossChainDeploy.s.sol --tc CrossChainDeployScript
- *         --sender <the_caller_address> --fork-url $GOERLI_RPC_URL -vvvv` in
- *         the terminal. To run it for real, change it to
- *         `FOUNDRY_PROFILE=examples forge script
- *         script/examples/CrossChainDeploy.s.sol --tc CrossChainDeployScript
- *         --private-key $MY_ACTUAL_PK_BE_CAREFUL --fork-url $GOERLI_RPC_URL
- *         --broadcast`.
+ * @notice Deploys BalanceManager to the same CREATE2 address on every chain that
+ *         hosts 0age's ImmutableCreate2Factory (examples profile).
  *
+ * Preferred (encrypted keystore):
+ *   cast wallet import deployer --interactive
+ *   FOUNDRY_PROFILE=examples forge script script/examples/CrossChainDeploy.s.sol \
+ *     --tc CrossChainDeployScript --account deployer --rpc-url sepolia --broadcast
+ *
+ * Simulate:
+ *   FOUNDRY_PROFILE=examples forge script script/examples/CrossChainDeploy.s.sol \
+ *     --tc CrossChainDeployScript --sender <address> --fork-url $SEPOLIA_RPC_URL -vvvv
  */
-contract CrossChainDeployScript is Script {
-    // Define a mapping from chainID to its respective URL
-    mapping(uint256 => string) chainToBlockExplorer;
-
-    // Set up the immutable create2 factory and conduit controller addresses.
-    // this is an already deployed address of z0age's CREATE2Factory contract
-    ImmutableCreate2Factory private constant IMMUTABLE_CREATE2_FACTORY =
-        ImmutableCreate2Factory(0x0000000000FFe8B47B3e2130213B802212439497);
-
-    // Set up the default salt. To deploy with a specific salt, replace it here
-    // or pass it in as an argument to the `deploy` function below.
-    bytes32 private constant DEFAULT_SALT = bytes32(uint256(0x1));
+contract CrossChainDeployScript is DeployBase {
+    mapping(uint256 => string) private chainToBlockExplorer;
 
     function setUp() public {
-        // Populate the chainToBlockExplorer mappings.
         _setPrefixValues();
     }
 
     function run() public {
-        vm.startBroadcast();
+        _startBroadcast();
+        // Bake the broadcaster into init code so Ownable gets a non-zero owner
+        // and the CREATE2 address stays stable across chains for a given salt.
+        address deployed = _deploy(bytes.concat(type(BalanceManager).creationCode, abi.encode(deployer)));
+        _stopBroadcast();
 
-        // Create a new BalanceManager contract.
-        deploy(bytes.concat(type(BalanceManager).creationCode, abi.encode(msg.sender)));
-
-        vm.stopBroadcast();
+        _writeDeployment("BalanceManager", deployed);
     }
 
-    function deploy(bytes memory initCode) internal returns (address) {
-        return deploy(DEFAULT_SALT, initCode);
+    function _deploy(bytes memory initCode) internal returns (address) {
+        return _deploy(DEFAULT_SALT, initCode);
     }
 
-    function deploy(bytes32 salt, bytes memory initCode) internal returns (address) {
+    function _deploy(bytes32 salt, bytes memory initCode) internal returns (address) {
         bytes32 initCodeHash = keccak256(initCode);
-        address deploymentAddress = address(
-            uint160(
-                uint256(keccak256(abi.encodePacked(hex"ff", address(IMMUTABLE_CREATE2_FACTORY), salt, initCodeHash)))
-            )
-        );
-        bool deploying;
-        if (!IMMUTABLE_CREATE2_FACTORY.hasBeenDeployed(deploymentAddress)) {
-            deploymentAddress = IMMUTABLE_CREATE2_FACTORY.safeCreate2(salt, initCode);
-            deploying = true;
-        }
+        (address deploymentAddress, bool deployedNow) = _deployCreate2(salt, initCode);
 
-        if (!deploying) {
+        if (!deployedNow) {
             console.log(
-                pad("Found", 10),
-                pad(LibString.toHexString(deploymentAddress), 43),
+                _pad("Found", 10),
+                _pad(LibString.toHexString(deploymentAddress), 43),
                 LibString.toHexString(uint256(initCodeHash))
             );
-        } else {
-            // The `"\x1b[1m%s\x1b[0m"` causes the string to be printed in bold.
-            string memory boldString = "\x1b[1m%s\x1b[0m";
-            string memory deployHypeString = _chainIsSupportedByABlockExplorer()
-                ? "Deployed LazerToken contract at:"
-                : "Deployed LazerToken contract!";
-
-            console.log(boldString, deployHypeString);
-            console.log(boldString, _getBlockExplorerLog(deploymentAddress));
-            console.log("");
-            console.log(boldString, "Initialization code hash:", LibString.toHexString(uint256(initCodeHash)));
+            return deploymentAddress;
         }
 
+        string memory bold = "\x1b[1m%s\x1b[0m";
+        console.log(
+            bold, _chainIsSupportedByABlockExplorer() ? "Deployed BalanceManager at:" : "Deployed BalanceManager!"
+        );
+        console.log(bold, _getBlockExplorerLog(deploymentAddress));
+        console.log("");
+        console.log(bold, "Initialization code hash:", LibString.toHexString(uint256(initCodeHash)));
         return deploymentAddress;
     }
 
-    function pad(string memory name, uint256 n) internal pure returns (string memory) {
+    function _pad(string memory name, uint256 n) internal pure returns (string memory) {
         string memory padded = name;
         while (bytes(padded).length < n) {
             padded = string.concat(padded, " ");
@@ -108,44 +72,29 @@ contract CrossChainDeployScript is Script {
         return padded;
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                           Log Helpers                                  //
-    ////////////////////////////////////////////////////////////////////////////
-
     function _getBlockExplorerLog(address targetContract) internal view returns (string memory) {
-        // Only return a log if the chain is supported.
-        string memory blockExplorerString = string(
-            abi.encodePacked(
-                "View the contract on a block explorer: ",
-                chainToBlockExplorer[block.chainid],
-                vm.toString(targetContract)
-            )
+        string memory blockExplorerString = string.concat(
+            "View the contract on a block explorer: ", chainToBlockExplorer[block.chainid], vm.toString(targetContract)
         );
-
         return _chainIsSupportedByABlockExplorer() ? blockExplorerString : "";
     }
 
     function _chainIsSupportedByABlockExplorer() internal view returns (bool) {
-        return keccak256(bytes(chainToBlockExplorer[block.chainid])) != keccak256(bytes(""));
+        return bytes(chainToBlockExplorer[block.chainid]).length != 0;
     }
 
     function _setPrefixValues() internal {
         chainToBlockExplorer[1] = "https://etherscan.io/address/";
-        chainToBlockExplorer[5] = "https://goerli.etherscan.io/address/";
         chainToBlockExplorer[11155111] = "https://sepolia.etherscan.io/address/";
         chainToBlockExplorer[137] = "https://polygonscan.com/address/";
-        chainToBlockExplorer[80001] = "https://mumbai.polygonscan.com/address/";
         chainToBlockExplorer[43114] = "https://snowtrace.io/address/";
-        chainToBlockExplorer[43113] = "https://testnet.snowtrace.io/address/";
         chainToBlockExplorer[100] = "https://gnosisscan.io/address/";
         chainToBlockExplorer[10200] = "https://gnosis-chiado.blockscout.com/address/";
         chainToBlockExplorer[42161] = "https://arbiscan.io/address/";
-        chainToBlockExplorer[421613] = "https://goerli.arbiscan.io/address/";
         chainToBlockExplorer[42170] = "https://nova.arbiscan.io/address/";
         chainToBlockExplorer[10] = "https://optimistic.etherscan.io/address/";
-        chainToBlockExplorer[420] = "https://goerli-optimism.etherscan.io/address/";
         chainToBlockExplorer[8453] = "https://basescan.org/address/";
-        chainToBlockExplorer[84531] = "https://goerli.basescan.org/address";
+        chainToBlockExplorer[84532] = "https://sepolia.basescan.org/address/";
         chainToBlockExplorer[7777777] = "https://explorer.zora.energy/address/";
         chainToBlockExplorer[999] = "https://testnet.explorer.zora.energy/address/";
     }

--- a/script/examples/DeployBalanceManager.s.sol
+++ b/script/examples/DeployBalanceManager.s.sol
@@ -1,27 +1,36 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
-import "forge-std/Script.sol";
-import "../../examples/BalanceManager.sol";
+import {console} from "forge-std/console.sol";
+import {BalanceManager} from "../../examples/BalanceManager.sol";
+import {DeployBase} from "../utils/DeployBase.s.sol";
 
 /**
  * @title DeployBalanceManager
- * @notice This script deploys BalanceManager. Simulate running it by entering
- *         `forge script script/examples/DeployBalanceManager.s.sol --sender <the_caller_address>
- *         --fork-url $SEPOLIA_RPC_URL -vvvv` in the terminal. To run it for
- *         real, change it to `forge script script/examples/DeployBalanceManager.s.sol
- *         --fork-url $SEPOLIA_RPC_URL --broadcast`.
- *         Requires FOUNDRY_PROFILE=examples.
+ * @notice Deploys BalanceManager with the broadcaster as `initialOwner` (examples profile).
+ *
+ * Preferred (encrypted keystore):
+ *   cast wallet import deployer --interactive
+ *   FOUNDRY_PROFILE=examples forge script script/examples/DeployBalanceManager.s.sol \
+ *     --account deployer --rpc-url sepolia --broadcast --verify
+ *
+ * CI / automation (plaintext key in the environment):
+ *   FOUNDRY_PROFILE=examples forge script script/examples/DeployBalanceManager.s.sol \
+ *     --rpc-url sepolia --broadcast
+ *   # with DEPLOYER_PRIVATE_KEY set
+ *
+ * Simulate without broadcasting:
+ *   FOUNDRY_PROFILE=examples forge script script/examples/DeployBalanceManager.s.sol \
+ *     --sender <address> --fork-url $SEPOLIA_RPC_URL -vvvv
  */
-contract DeployBalanceManager is Script {
+contract DeployBalanceManager is DeployBase {
     function run() public {
-        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
-        // OpenZeppelin's Ownable rejects the zero address, and BalanceManager now
-        // actually honours this argument, so hand it the broadcasting account
-        address deployer = vm.addr(deployerPrivateKey);
-
-        vm.broadcast(deployerPrivateKey);
+        _startBroadcast();
+        // OpenZeppelin's Ownable rejects address(0); pass the broadcasting account.
         BalanceManager balanceManager = new BalanceManager(deployer);
+        _stopBroadcast();
+
+        _writeDeployment("BalanceManager", address(balanceManager));
         console.log("BalanceManager deployed at:", address(balanceManager));
     }
 }

--- a/script/examples/DeployCREATE3Factory.s.sol
+++ b/script/examples/DeployCREATE3Factory.s.sol
@@ -1,46 +1,29 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {console} from "forge-std/console.sol";
 import {CREATE3Factory} from "../../examples/CREATE3Factory.sol";
+import {DeployBase} from "../utils/DeployBase.s.sol";
 
-import {Utils} from "../utils/Utils.sol";
-
-contract DeployCREATE3Factory is Utils {
-    CREATE3Factory factory;
-
-    address deployer;
-
+/**
+ * @title DeployCREATE3Factory
+ * @notice Deploys CREATE3Factory (examples profile).
+ *
+ * Preferred (encrypted keystore):
+ *   cast wallet import deployer --interactive
+ *   FOUNDRY_PROFILE=examples forge script script/examples/DeployCREATE3Factory.s.sol \
+ *     --account deployer --rpc-url sepolia --broadcast --verify
+ *
+ * CI / automation: set DEPLOYER_PRIVATE_KEY and omit `--account`.
+ */
+contract DeployCREATE3Factory is DeployBase {
     function run() public {
-        uint256 privateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
-        require(privateKey != 0, "DEPLOYER_PRIVATE_KEY not set");
-
-        deployer = vm.addr(privateKey);
-        vm.startBroadcast(privateKey);
-
-        factory = new CREATE3Factory();
+        _startBroadcast();
+        CREATE3Factory factory = new CREATE3Factory();
         require(address(factory) != address(0), "CREATE3Factory deployment failed");
+        _stopBroadcast();
 
-        vm.stopBroadcast();
-
-        _serializeDeploymentData();
-    }
-
-    function _serializeDeploymentData() internal {
-        string memory parent_object = "parent object";
-        string memory addresses = "addresses";
-        string memory constructorArgs = "constructorArgs";
-
-        string memory addressesOutput;
-        addressesOutput = vm.serializeAddress(addresses, "deployer", deployer);
-        addressesOutput = vm.serializeAddress(addresses, "implementation", address(factory));
-
-        string memory constructorArgsOutput;
-
-        string memory finalJson;
-        finalJson = vm.serializeString(parent_object, addresses, addressesOutput);
-        finalJson = vm.serializeString(parent_object, constructorArgs, constructorArgsOutput);
-        finalJson = vm.serializeUint(parent_object, "deploymentBlock", block.number);
-
-        writeOutput(finalJson, "CREATE3Factory");
+        _writeDeployment("CREATE3Factory", address(factory));
+        console.log("CREATE3Factory deployed at:", address(factory));
     }
 }

--- a/script/examples/DeployInflationToken.s.sol
+++ b/script/examples/DeployInflationToken.s.sol
@@ -1,22 +1,35 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
-import "forge-std/Script.sol";
-import "../../examples/InflationToken.sol";
+import {console} from "forge-std/console.sol";
+import {InflationToken} from "../../examples/InflationToken.sol";
+import {DeployBase} from "../utils/DeployBase.s.sol";
 
 /**
  * @title DeployInflationToken
- * @notice This script deploys InflationToken. Simulate running it by entering
- *         `forge script script/examples/DeployInflationToken.s.sol --sender <the_caller_address>
- *         --fork-url $SEPOLIA_RPC_URL -vvvv` in the terminal. To run it for
- *         real, change it to `forge script script/examples/DeployInflationToken.s.sol
- *         --fork-url $SEPOLIA_RPC_URL --broadcast`.
- *         Requires FOUNDRY_PROFILE=examples.
+ * @notice Deploys InflationToken (examples profile).
+ *
+ * Preferred (encrypted keystore):
+ *   cast wallet import deployer --interactive
+ *   FOUNDRY_PROFILE=examples forge script script/examples/DeployInflationToken.s.sol \
+ *     --account deployer --rpc-url sepolia --broadcast --verify
+ *
+ * CI / automation (plaintext key in the environment):
+ *   FOUNDRY_PROFILE=examples forge script script/examples/DeployInflationToken.s.sol \
+ *     --rpc-url sepolia --broadcast
+ *   # with DEPLOYER_PRIVATE_KEY set
+ *
+ * Simulate without broadcasting:
+ *   FOUNDRY_PROFILE=examples forge script script/examples/DeployInflationToken.s.sol \
+ *     --sender <address> --fork-url $SEPOLIA_RPC_URL -vvvv
  */
-contract DeployInflationToken is Script {
+contract DeployInflationToken is DeployBase {
     function run() public {
-        vm.broadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        _startBroadcast();
         InflationToken inflationToken = new InflationToken();
+        _stopBroadcast();
+
+        _writeDeployment("InflationToken", address(inflationToken));
         console.log("InflationToken deployed at:", address(inflationToken));
     }
 }

--- a/script/utils/DeployBase.s.sol
+++ b/script/utils/DeployBase.s.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+
+/// @dev 0age's ImmutableCreate2Factory, deployed on every major EVM chain.
+interface ImmutableCreate2Factory {
+    function hasBeenDeployed(address deploymentAddress) external view returns (bool);
+
+    function findCreate2Address(bytes32 salt, bytes calldata initializationCode)
+        external
+        view
+        returns (address deploymentAddress);
+
+    function safeCreate2(bytes32 salt, bytes calldata initializationCode)
+        external
+        payable
+        returns (address deploymentAddress);
+}
+
+/**
+ * @title DeployBase
+ * @notice Shared deploy plumbing for LazerForge scripts.
+ *
+ * Prefer an encrypted keystore account at the CLI:
+ *
+ *   cast wallet import deployer --interactive
+ *   forge script script/DeployCounter.s.sol --account deployer --rpc-url base --broadcast
+ *
+ * `DEPLOYER_PRIVATE_KEY` remains supported for CI / automation only.
+ *
+ * Successful broadcasts append addresses to `deployments/<chainid>.json`.
+ */
+abstract contract DeployBase is Script {
+    ImmutableCreate2Factory internal constant IMMUTABLE_CREATE2_FACTORY =
+        ImmutableCreate2Factory(0x0000000000FFe8B47B3e2130213B802212439497);
+
+    bytes32 internal constant DEFAULT_SALT = bytes32(uint256(0x1));
+
+    /// @dev Broadcaster resolved by `_startBroadcast` / `_loadDeployer`.
+    address internal deployer;
+
+    // -------------------------------------------------------------------------
+    // Broadcast
+    // -------------------------------------------------------------------------
+
+    /// @dev Resolve the deployer without starting a broadcast.
+    ///      Keystore / `--account` path: uses the active script sender.
+    ///      CI path: derives the address from `DEPLOYER_PRIVATE_KEY`.
+    function _loadDeployer() internal {
+        if (vm.envExists("DEPLOYER_PRIVATE_KEY")) {
+            uint256 privateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+            require(privateKey != 0, "DEPLOYER_PRIVATE_KEY is zero");
+            deployer = vm.addr(privateKey);
+            return;
+        }
+
+        (, address msgSender,) = vm.readCallers();
+        require(msgSender != address(0), "no deployer: use --account or set DEPLOYER_PRIVATE_KEY");
+        deployer = msgSender;
+    }
+
+    /// @dev Start broadcasting as the keystore account, or the CI private key.
+    function _startBroadcast() internal {
+        _loadDeployer();
+        if (vm.envExists("DEPLOYER_PRIVATE_KEY")) {
+            vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        } else {
+            vm.startBroadcast();
+        }
+    }
+
+    function _stopBroadcast() internal {
+        vm.stopBroadcast();
+    }
+
+    // -------------------------------------------------------------------------
+    // CREATE2
+    // -------------------------------------------------------------------------
+
+    /// @dev Deterministic salt from a human-readable label.
+    function _salt(string memory label) internal pure returns (bytes32) {
+        return keccak256(bytes(label));
+    }
+
+    /// @dev Optional `CREATE2_SALT` env override; otherwise `_salt(label)`.
+    function _saltOrDefault(string memory label) internal view returns (bytes32) {
+        if (vm.envExists("CREATE2_SALT")) {
+            return vm.envBytes32("CREATE2_SALT");
+        }
+        return _salt(label);
+    }
+
+    function _predictCreate2(bytes32 salt, bytes memory initCode) internal pure returns (address) {
+        return address(
+            uint160(
+                uint256(
+                    keccak256(abi.encodePacked(hex"ff", address(IMMUTABLE_CREATE2_FACTORY), salt, keccak256(initCode)))
+                )
+            )
+        );
+    }
+
+    /// @return deployment The CREATE2 address (existing or newly deployed).
+    /// @return deployedNow True when this call submitted `safeCreate2`.
+    function _deployCreate2(bytes32 salt, bytes memory initCode)
+        internal
+        returns (address deployment, bool deployedNow)
+    {
+        deployment = _predictCreate2(salt, initCode);
+        if (IMMUTABLE_CREATE2_FACTORY.hasBeenDeployed(deployment)) {
+            return (deployment, false);
+        }
+        deployment = IMMUTABLE_CREATE2_FACTORY.safeCreate2(salt, initCode);
+        return (deployment, true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Deployment records — deployments/<chainid>.json
+    // -------------------------------------------------------------------------
+
+    function _deploymentsDir() internal view returns (string memory) {
+        return string.concat(vm.projectRoot(), "/deployments/");
+    }
+
+    function _deploymentsPath() internal view returns (string memory) {
+        return string.concat(_deploymentsDir(), vm.toString(block.chainid), ".json");
+    }
+
+    function _ensureDeploymentsDir() internal {
+        string memory dir = _deploymentsDir();
+        if (!vm.exists(dir)) {
+            vm.createDir(dir, true);
+        }
+    }
+
+    /// @dev Merge `name -> addr` into `deployments/<chainid>.json`.
+    function _writeDeployment(string memory name, address addr) internal {
+        _ensureDeploymentsDir();
+        string memory path = _deploymentsPath();
+
+        if (!vm.exists(path)) {
+            vm.writeFile(path, "{}\n");
+        }
+
+        // `writeJson` with a value key updates in place without clobbering siblings.
+        string memory value = string.concat("\"", vm.toString(addr), "\"");
+        vm.writeJson(value, path, string.concat(".", name));
+    }
+
+    /// @dev Read a previously recorded address. Reverts if the file or key is missing.
+    function _readDeployment(string memory name) internal view returns (address) {
+        return vm.parseJsonAddress(vm.readFile(_deploymentsPath()), string.concat(".", name));
+    }
+}

--- a/script/utils/Utils.sol
+++ b/script/utils/Utils.sol
@@ -1,38 +1,37 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Script} from "forge-std/Script.sol";
+import {DeployBase} from "./DeployBase.s.sol";
 
-contract Utils is Script {
+/**
+ * @title Utils
+ * @notice Thin helpers on top of {DeployBase}. Prefer `_writeDeployment` for new
+ *         scripts — these named-file APIs now resolve to `deployments/<chainid>.json`.
+ */
+abstract contract Utils is DeployBase {
     uint256 constant CHAIN_ID_ANVIL_LOCALNET = 31_337;
 
     string constant OUTPUT_ANVIL_LOCALNET = "anvil_localnet";
     string constant OUTPUT_UNKNOWN = "unknown";
 
     function readInput(string memory inputFileName) internal view returns (string memory) {
-        string memory file = getInputPath(inputFileName);
-        return vm.readFile(file);
+        return vm.readFile(getInputPath(inputFileName));
     }
 
     function getInputPath(string memory inputFileName) internal view returns (string memory) {
-        string memory inputDir = string.concat(vm.projectRoot(), "/deployments/");
-        string memory file = string.concat(inputFileName, ".json");
-        return string.concat(inputDir, file);
+        return string.concat(_deploymentsDir(), inputFileName, ".json");
     }
 
-    function readOutput(string memory outputFileName) internal view returns (string memory) {
-        string memory file = getOutputPath(outputFileName);
-        return vm.readFile(file);
+    function readOutput(string memory) internal view returns (string memory) {
+        return vm.readFile(_deploymentsPath());
     }
 
-    function writeOutput(string memory outputJson, string memory outputFileName) internal {
-        string memory outputFilePath = getOutputPath(outputFileName);
-        vm.writeJson(outputJson, outputFilePath);
+    function writeOutput(string memory outputJson, string memory) internal {
+        _ensureDeploymentsDir();
+        vm.writeJson(outputJson, _deploymentsPath());
     }
 
-    function getOutputPath(string memory outputFileName) internal view returns (string memory) {
-        string memory outputDir = string.concat(vm.projectRoot(), "/deployments/");
-        string memory outputFilePath = string.concat(outputDir, outputFileName, ".json");
-        return outputFilePath;
+    function getOutputPath(string memory) internal view returns (string memory) {
+        return _deploymentsPath();
     }
 }

--- a/variants/minimal.yml
+++ b/variants/minimal.yml
@@ -32,3 +32,5 @@ remove:
   - variants/
   - tools/
   - .github/workflows/build-variants.yml
+  # examples CI — no examples/ tree on this variant
+  - .github/workflows/examples.yml


### PR DESCRIPTION
## Summary

- Closes #36: encrypted keystore (`cast wallet import` + `--account`) is the documented default deploy path; `DEPLOYER_PRIVATE_KEY` is CI/automation only
- Adds `script/utils/DeployBase.s.sol` with shared broadcast plumbing, CREATE2 salt/deploy helpers, and a per-chain `deployments/<chainid>.json` writer
- Rebased onto #46's `examples/` layout: starter `script/DeployCounter.s.sol` uses DeployBase (survives on `variant/minimal`); demo scripts live under `script/examples/`
- **Fixes the `Build Variant Branches` failure on main after #46:** stop using `variant:` markers in workflow YAML (stripped content is unique and `GITHUB_TOKEN` cannot push it). Gate examples CI at runtime instead so workflow files stay identical across branches.

## Changes

- [x] `script/utils/DeployBase.s.sol` — keystore-first `_startBroadcast`, `_salt` / `_deployCreate2`, `_writeDeployment`
- [x] `script/DeployCounter.s.sol` + `script/examples/*` deploy scripts wired through DeployBase
- [x] Docs / `sample.env` teach keystore first with `DeployCounter` as the default example
- [x] `foundry.toml` grants `deployments/` write access; `deployments/.gitkeep` + ignore anvil `31337.json`
- [x] Workflows + `CONTRIBUTING.md`: runtime examples gates, no variant markers in `.github/workflows/`

## Checklist

- [x] `forge fmt`
- [x] `forge test` / `FOUNDRY_PROFILE=examples forge test`
- [x] `just variant minimal --ref HEAD` — generated `lint.yml` / `test.yml` / `fix-lint.yml` are byte-identical to `main`

## Test plan

- [ ] After merge, confirm `Build Variant Branches` on `main` publishes `variant/minimal` successfully
- [ ] `forge script script/DeployCounter.s.sol --sender <addr> -vvvv` writes `deployments/31337.json` without `DEPLOYER_PRIVATE_KEY`
- [ ] Example path: `FOUNDRY_PROFILE=examples forge script script/examples/DeployInflationToken.s.sol --account deployer …`