### PR TITLE
🐛 unbreak variant publishing, broken since #46

### DIFF
--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -57,9 +57,9 @@ jobs:
           set -euo pipefail
 
           forge fmt
-          # variant:full:start
-          FOUNDRY_PROFILE=examples forge fmt
-          # variant:full:end
+          if [ -d examples ]; then
+            FOUNDRY_PROFILE=examples forge fmt
+          fi
 
           if git diff --quiet; then
             echo "::notice::Formatting is already correct, nothing to fix."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,9 +37,12 @@ jobs:
           echo "Running forge fmt --check"
           failed=0
           forge fmt --check || failed=1
-          # variant:full:start
-          FOUNDRY_PROFILE=examples forge fmt --check || failed=1
-          # variant:full:end
+          # examples/ is absent on generated variants and on any tree where the
+          # demos were deleted; see the note in test.yml about why this is a
+          # runtime guard rather than a variant marker
+          if [ -d examples ]; then
+            FOUNDRY_PROFILE=examples forge fmt --check || failed=1
+          fi
           if [ "$failed" -ne 0 ]; then
             echo "The formatting check failed. You can fix it locally with 'just fmt' and then push, or you can have a GitHub action take care of it for you by commenting '!fix' on the PR."
             exit 1
@@ -50,9 +53,9 @@ jobs:
         run: |
           set -euo pipefail
           forge lint --severity high --severity med 2>&1 | tee lint.log
-          # variant:full:start
-          FOUNDRY_PROFILE=examples forge lint --severity high --severity med 2>&1 | tee -a lint.log
-          # variant:full:end
+          if [ -d examples ]; then
+            FOUNDRY_PROFILE=examples forge lint --severity high --severity med 2>&1 | tee -a lint.log
+          fi
           if grep -qE '^(warning|error)\[' lint.log; then
             echo "forge lint reported findings above. Fix them, or add a"
             echo "'// forge-lint: disable-next-line(<id>)' comment with a justification."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,11 @@ jobs:
         id: test
         run: forge test -vvv
 
-  # variant:full:start
+  # These jobs are a no-op on any tree without examples/ - a generated variant
+  # branch, or a consumer who deleted the demos. They are guarded at runtime
+  # rather than stripped by a variant marker on purpose: GITHUB_TOKEN cannot
+  # push workflow files that differ from the ones on main, so the variant build
+  # can only publish while these files stay byte-identical. See #50.
   examples:
     name: Examples
     runs-on: ubuntu-latest
@@ -55,10 +59,14 @@ jobs:
       # the contracts big enough to approach the 24KB limit all live here, so
       # this is where the size check earns its keep
       - name: Build examples
-        run: forge build --sizes
+        run: |
+          if [ ! -d examples ]; then echo "no examples/ in this tree - skipping"; exit 0; fi
+          forge build --sizes
 
       - name: Test examples
-        run: forge test -vvv
+        run: |
+          if [ ! -d examples ]; then echo "no examples/ in this tree - skipping"; exit 0; fi
+          forge test -vvv
 
   gas:
     name: Gas snapshot
@@ -75,8 +83,9 @@ jobs:
       # inputs, so they cannot gate PRs. Update the committed snapshot with
       # the same filter after a gas-affecting change.
       - name: Check gas snapshot
-        run: forge snapshot --check --nmt 'test_fuzz|testFuzz|invariant'
-  # variant:full:end
+        run: |
+          if [ ! -d examples ]; then echo "no examples/ in this tree - skipping"; exit 0; fi
+          forge snapshot --check --nmt 'test_fuzz|testFuzz|invariant'
 
   coverage:
     name: Coverage


### PR DESCRIPTION
## Description

**The variant build has failed on every push to `main` since #46.** `variant/minimal` is stale — it sits at `main@a351f7b` while `main` is four commits ahead, so the published branch is missing the examples move entirely.

The failure is in the publish step:

```
! [remote rejected] HEAD -> variant/minimal (refusing to allow a GitHub App to
  create or update workflow `.github/workflows/lint.yml` without `workflows` permission)
```

`GITHUB_TOKEN` cannot create or update files under `.github/workflows/`, and `workflows` is **not** a grantable key in a workflow `permissions:` block — so this cannot be fixed with configuration.

## Why it worked before

Every previously published variant workflow file was byte-identical to `main`'s, so the push introduced no new workflow content and GitHub allowed it. I verified this against the published branch:

```
IDENTICAL: test.yml
IDENTICAL: lint.yml
IDENTICAL: fix-lint.yml
```

#46 added `variant:full` regions to `test.yml`, and the review follow-up added them to `lint.yml` and `fix-lint.yml`. That made the generated versions genuinely differ from `main`'s, and the push has been rejected ever since. My follow-up commit is as much to blame as the original PR.

## Fix

The examples-dependent steps are guarded at runtime on the presence of `examples/` rather than stripped by a variant marker, so all three workflow files stay identical across `main` and every variant:

```yaml
- name: Build examples
  run: |
    if [ ! -d examples ]; then echo "no examples/ in this tree - skipping"; exit 0; fi
    forge build --sizes
```

A job-level `if:` with `hashFiles()` would be tidier, but job-level conditions evaluate before checkout, so it would skip unconditionally.

## Side benefit

This fixes the same breakage for template consumers. Deleting `examples/` is the expected first step, and until now that left them with CI failing immediately on a directory they were told to remove. Related to #48.

## Verification

- Generated `variant/minimal` from this branch: `test.yml`, `lint.yml` and `fix-lint.yml` are now **byte-identical** to `main`'s — the exact condition the earlier successful publishes met
- `build-variants.yml` still correctly absent from the variant; the `setup-foundry` composite action still present
- Guard confirmed to fire on the variant (no `examples/`), so all three steps no-op
- Variant tree: installs, builds, 2 tests pass, `fmt --check` clean
- `main` unaffected: 2 tests default, 29 under `FOUNDRY_PROFILE=examples`, both profiles `fmt --check` clean

## Note

This restores publishing but does not remove the ceiling: variant branches can never carry CI that differs from `main` without a PAT or GitHub App token. That constraint is one of the inputs to #50, which asks whether variant branches are still worth their cost now that `examples/` has moved out of `src/`.

## Checklist

- [x] `forge fmt`
- [x] `forge test`